### PR TITLE
Add LLM integration and context query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+hyperhelix.log
+errors.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository Guidelines
+
+- Keep the directory structure described in `README.md` when adding files.
+- Configure logging using `config/logging.yaml`; logs should write to `hyperhelix.log` and errors to `errors.log`.
+- Remove any `TODO` comments before committing; track outstanding work in issues or documentation.
+- Run available tests with `pytest` before each commit. If no tests exist, ensure your changes at least import correctly.
+- Update documentation whenever new functionality is introduced.
+- Set any LLM provider keys (e.g. `OPENAI_API_KEY`) in the environment before running tests or code.
+- Detailed build instructions live in `docs/AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,5 @@
 - Run available tests with `pytest` before each commit. If no tests exist, ensure your changes at least import correctly.
 - Update documentation whenever new functionality is introduced.
 - Set any LLM provider keys (e.g. `OPENAI_API_KEY`) in the environment before running tests or code.
+- Install dependencies with `pip install -r requirements.txt` before starting the API or container.
 - Detailed build instructions live in `docs/AGENTS.md`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["uvicorn", "hyperhelix.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ With this in place, your **Living Hyper-Helix**:
 - Orchestrates entire software projects and teams
 - Renders in 3D, responds to chat and webhook events
 - Scales from a single developer to global micro-services
+- Self-heals by pruning broken edges and weaving new nodes by shared tags
+- Records execution results in each node's perception history
 - Quickly queries context with `find_nodes_by_tag` and integrates responses from popular LLMs
 
 This is the full system—every file, class and function—powering a zero-bloat, infinitely weaving digital brain.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Alternatively build and run the provided Dockerfile:
 docker build -t helixhyper .
 docker run -p 8000:8000 helixhyper
 ```
+
+## API Usage
+With the server running you can create nodes and edges via HTTP:
+
+```bash
+curl -X POST http://localhost:8000/nodes -H 'Content-Type: application/json' \
+     -d '{"id": "a", "payload": {"foo": "bar"}}'
+
+curl -X POST http://localhost:8000/edges -H 'Content-Type: application/json' \
+     -d '{"a": "a", "b": "b"}'
+
+curl http://localhost:8000/walk/a?depth=1
+```
 ```
 hyperhelix_system/
 ├── README.md

--- a/README.md
+++ b/README.md
@@ -4,11 +4,25 @@ HelixHyper orchestrates code analysis, task management and execution through a m
 HelixHyper provides a minimal implementation alongside documentation and configuration. The layout below outlines the complete system as it grows.
 
 ## Getting Started
-Install dependencies and run the small test suite to verify the environment:
+Clone the repository and install all dependencies before running any commands.
 
 ```bash
+git clone <repo-url> && cd HelixHyper
 pip install -r requirements.txt
 python -m pytest -q
+```
+
+Start the API once tests pass:
+
+```bash
+uvicorn hyperhelix.api.main:app --reload
+```
+
+Alternatively build and run the provided Dockerfile:
+
+```bash
+docker build -t helixhyper .
+docker run -p 8000:8000 helixhyper
 ```
 ```
 hyperhelix_system/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Start the API once tests pass:
 uvicorn hyperhelix.api.main:app --reload
 ```
 
+You can also run the server via the CLI command:
+
+```bash
+python -m hyperhelix.cli.commands serve
+```
+
 Alternatively build and run the provided Dockerfile:
 
 ```bash
@@ -156,6 +162,7 @@ The directories above form a cohesive system:
 ## Logging and Error Management
 Python's `logging` package is configured through `config/logging.yaml`. Logs are emitted to the console and stored in `hyperhelix.log`, while errors are also written to `errors.log`. Tune log levels in that file to match the environment. When handling exceptions, log the failure with context and either re-raise or return a meaningful error to callers. Avoid TODO markers in committed code—track outstanding work in issue trackers or documentation.
 The graph core validates nodes when creating edges and logs an error if a referenced node is missing. `spiral_walk` checks the starting node ID and raises `KeyError` when absent. Each node updates its `metadata.updated` timestamp whenever `execute()` runs so event timing stays accurate.
+The engine also provides event hooks. `evented_engine.on_insert` is registered automatically and recalculates importance and permanence whenever a node is added. You can register custom callbacks with `register_insert_hook` or `register_update_hook` to persist data or trigger other tasks.
 
 ## LLM Integration
 Use the helpers in `hyperhelix.agents.llm` to connect to popular language models such as OpenAI. Chat messages can be processed with `handle_chat_message`, which stores the conversation in the graph and records any model replies. Set provider keys like `OPENAI_API_KEY` in the environment so integrations work correctly.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,121 @@
 # HelixHyper
-A context engine for AI growing accurate program enhancement and code suggestions, real feedback on data and systems. Self learning and self healing
+
+HelixHyper orchestrates code analysis, task management and execution through a multi-layered graph structure.
+HelixHyper provides a minimal implementation alongside documentation and configuration. The layout below outlines the complete system as it grows.
+
+## Getting Started
+Install dependencies and run the small test suite to verify the environment:
+
+```bash
+pip install -r requirements.txt
+python -m pytest -q
+```
+```
+hyperhelix_system/
+├── README.md
+├── LICENSE
+├── setup.py
+├── requirements.txt
+├── config/
+│   ├── default.yaml
+│   ├── logging.yaml
+│   └── persistence.yaml
+├── hyperhelix/
+│   ├── __init__.py
+│   ├── node.py
+│   ├── edge.py
+│   ├── metadata.py
+│   ├── core.py
+│   ├── analytics/
+│   │   ├── importance.py
+│   │   └── permanence.py
+│   ├── evolution/
+│   │   ├── evented_engine.py
+│   │   └── continuous_engine.py
+│   ├── execution/
+│   │   ├── executor.py
+│   │   └── hook_manager.py
+│   ├── tasks/
+│   │   ├── task.py
+│   │   ├── task_manager.py
+│   │   └── sprint_planner.py
+│   ├── persistence/
+│   │   ├── base_adapter.py
+│   │   ├── neo4j_adapter.py
+│   │   ├── qdrant_adapter.py
+│   │   └── sqlalchemy_adapter.py
+│   ├── api/
+│   │   ├── main.py
+│   │   ├── dependencies.py
+│   │   ├── schemas.py
+│   │   └── routers/
+│   │       ├── nodes.py
+│   │       ├── edges.py
+│   │       ├── walk.py
+│   │       └── bloom.py
+│   ├── cli/
+│   │   └── commands.py
+│   ├── visualization/
+│   │   ├── coords_generator.py
+│   │   └── threejs_renderer.py
+│   └── agents/
+│       ├── chat_adapter.py
+│       └── webhook_listener.py
+├── frontend/
+│   ├── package.json
+│   └── src/
+│       ├── App.jsx
+│       ├── GraphView.jsx
+│       └── services/
+│           └── hyperhelix_api.js
+├── tests/
+├── docs/
+```
+
+## Module Responsibilities
+The directories above form a cohesive system:
+- **config/** holds runtime constants, logging and persistence settings.
+- **hyperhelix/node.py** defines node fields (id, payload, tags, layer, strand, edges) and metadata (creation time, updates, importance, permanence, perception history) along with execution helpers.
+- **hyperhelix/core.py** provides the `HyperHelix` graph with thread-safe `add_node`, `add_edge` and `spiral_walk` operations.
+- **analytics/** recalculates node importance and permanence on demand.
+- **evolution/evented_engine.py** reacts instantly to insert/update hooks, pruning or weaving without polling.
+- **execution/** bridges external callables (builds, tests, deploys) into graph execution and auto-bloom hooks.
+- **tasks/** manages project tasks through graph-driven `create_task`, `assign_task` and `sprint_plan` helpers.
+- **persistence/** stores nodes and edges via pluggable adapters for Neo4j, Qdrant or SQLAlchemy.
+- **api/** exposes operations over REST and GraphQL using Pydantic schemas and optional auth stubs.
+- **cli/** offers local commands to initialise, import, export and serve the system.
+- **visualization/** generates 3D coordinates for Three.js rendering.
+ - **agents/** integrates chat interfaces and webhook events directly into the graph and provides helpers for LLM integrations.
+- **frontend/** is a reference React application to browse and edit the graph.
+- **tests/** keep all modules verified.
+- **docs/** provide architecture details and tutorials.
+
+## Logging and Error Management
+Python's `logging` package is configured through `config/logging.yaml`. Logs are emitted to the console and stored in `hyperhelix.log`, while errors are also written to `errors.log`. Tune log levels in that file to match the environment. When handling exceptions, log the failure with context and either re-raise or return a meaningful error to callers. Avoid TODO markers in committed code—track outstanding work in issue trackers or documentation.
+The graph core validates nodes when creating edges and logs an error if a referenced node is missing. `spiral_walk` checks the starting node ID and raises `KeyError` when absent. Each node updates its `metadata.updated` timestamp whenever `execute()` runs so event timing stays accurate.
+
+## LLM Integration
+Use the helpers in `hyperhelix.agents.llm` to connect to popular language models such as OpenAI. Chat messages can be processed with `handle_chat_message`, which stores the conversation in the graph and records any model replies. API keys are read from environment variables.
+
+## Contribution Guidelines
+- Follow the structure above when adding modules.
+- Keep logging consistent and avoid bare `except` clauses.
+- Update documentation whenever functionality changes.
+- Run available tests before submitting pull requests.
+
+For repository-specific instructions see [AGENTS.md](AGENTS.md).
+Detailed build and deployment guidance lives in [docs/AGENTS.md](docs/AGENTS.md).
+Each major module also provides its own `AGENTS.md` with focused guidelines.
+
+
+With this in place, your **Living Hyper-Helix**:
+- Loads & persists a spherical, self-evolving graph
+- Evolves instantly on every insert/update
+- Self-analyzes importance, permanence and perception shifts
+- Executes real-world code and tasks from nodes
+- Orchestrates entire software projects and teams
+- Renders in 3D, responds to chat and webhook events
+- Scales from a single developer to global micro-services
+- Quickly queries context with `find_nodes_by_tag` and integrates responses from popular LLMs
+
+This is the full system—every file, class and function—powering a zero-bloat, infinitely weaving digital brain.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ docker build -t helixhyper .
 docker run -p 8000:8000 helixhyper
 ```
 
+## Development Workflow
+Follow these practices when contributing to ensure consistent builds and clear logs:
+
+1. Install dependencies with `pip install -r requirements.txt` and set any required keys such as `OPENAI_API_KEY` in your environment.
+2. Run `pytest -q` to verify all modules import and tests succeed before committing.
+3. Configure logging via `config/logging.yaml`; runtime output goes to `hyperhelix.log` and errors to `errors.log`.
+4. Avoid leaving `TODO` comments in the code—track outstanding work in documentation or the issue tracker.
+
 ## API Usage
 With the server running you can create nodes and edges via HTTP:
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Python's `logging` package is configured through `config/logging.yaml`. Logs are
 The graph core validates nodes when creating edges and logs an error if a referenced node is missing. `spiral_walk` checks the starting node ID and raises `KeyError` when absent. Each node updates its `metadata.updated` timestamp whenever `execute()` runs so event timing stays accurate.
 
 ## LLM Integration
-Use the helpers in `hyperhelix.agents.llm` to connect to popular language models such as OpenAI. Chat messages can be processed with `handle_chat_message`, which stores the conversation in the graph and records any model replies. API keys are read from environment variables.
+Use the helpers in `hyperhelix.agents.llm` to connect to popular language models such as OpenAI. Chat messages can be processed with `handle_chat_message`, which stores the conversation in the graph and records any model replies. Set provider keys like `OPENAI_API_KEY` in the environment so integrations work correctly.
 
 ## Contribution Guidelines
 - Follow the structure above when adding modules.

--- a/README.md
+++ b/README.md
@@ -52,59 +52,87 @@ hyperhelix_system/
 ├── setup.py
 ├── requirements.txt
 ├── config/
-│   ├── default.yaml
-│   ├── logging.yaml
-│   └── persistence.yaml
-├── hyperhelix/
+│   ├── default.yaml             # all tunables (strands, thresholds, DB URIs…)
+│   ├── logging.yaml             # Python logging config
+│   └── persistence.yaml         # adapters (Neo4j, Qdrant, SQLAlchemy)
+├── hyperhelix/                  # core engine
 │   ├── __init__.py
-│   ├── node.py
-│   ├── edge.py
-│   ├── metadata.py
-│   ├── core.py
-│   ├── analytics/
-│   │   ├── importance.py
-│   │   └── permanence.py
-│   ├── evolution/
-│   │   ├── evented_engine.py
-│   │   └── continuous_engine.py
-│   ├── execution/
-│   │   ├── executor.py
-│   │   └── hook_manager.py
-│   ├── tasks/
-│   │   ├── task.py
-│   │   ├── task_manager.py
-│   │   └── sprint_planner.py
-│   ├── persistence/
-│   │   ├── base_adapter.py
-│   │   ├── neo4j_adapter.py
-│   │   ├── qdrant_adapter.py
-│   │   └── sqlalchemy_adapter.py
-│   ├── api/
-│   │   ├── main.py
-│   │   ├── dependencies.py
-│   │   ├── schemas.py
+│   ├── node.py                  # Node class (+payload, tags, layer, strand, edges, metadata)
+│   ├── edge.py                  # Edge helper (bidirectional connect, weight updates)
+│   ├── metadata.py              # metadata fields & perception_history logic
+│   ├── core.py                  # HyperHelix class (add_node, add_edge, spiral_walk)
+│   ├── analytics/               # self-analysis
+│   │   ├── __init__.py
+│   │   ├── importance.py        # compute_importance(node, all_nodes)
+│   │   └── permanence.py        # compute_permanence(node)
+│   ├── evolution/               # auto-evolution engines
+│   │   ├── __init__.py
+│   │   ├── evented_engine.py    # Event-driven (hooks → prune/weave/adjust)
+│   │   └── continuous_engine.py # optional interval fallback
+│   ├── execution/               # execution & agent hooks
+│   │   ├── __init__.py
+│   │   ├── executor.py          # Node.execute() wrapper
+│   │   └── hook_manager.py      # bind_recursion_to_task, on_insert/update hooks
+│   ├── tasks/                   # project & team orchestration
+│   │   ├── __init__.py
+│   │   ├── task.py              # Task node definitions (due, priority, assigned_to)
+│   │   ├── task_manager.py      # create_task(), assign_task()
+│   │   └── sprint_planner.py    # sprint_plan()
+│   ├── persistence/             # storage adapters
+│   │   ├── __init__.py
+│   │   ├── base_adapter.py      # interface (save_node, load_node, save_edge…)
+│   │   ├── neo4j_adapter.py     # graph DB backing store
+│   │   ├── qdrant_adapter.py    # vector DB for embeddings
+│   │   └── sqlalchemy_adapter.py# relational fallback
+│   ├── api/                     # FastAPI REST & GraphQL
+│   │   ├── __init__.py
+│   │   ├── main.py              # FastAPI()/include routers, CORS, auth
+│   │   ├── dependencies.py      # JWT/OAuth2 stubs
+│   │   ├── schemas.py           # Pydantic models (NodeIn, NodeOut, EdgeIn…)
 │   │   └── routers/
-│   │       ├── nodes.py
-│   │       ├── edges.py
-│   │       ├── walk.py
-│   │       └── bloom.py
-│   ├── cli/
-│   │   └── commands.py
-│   ├── visualization/
-│   │   ├── coords_generator.py
-│   │   └── threejs_renderer.py
-│   └── agents/
-│       ├── chat_adapter.py
-│       └── webhook_listener.py
-├── frontend/
+│   │       ├── nodes.py         # POST /nodes, GET /nodes/{id}
+│   │       ├── edges.py         # POST /edges
+│   │       ├── walk.py          # GET /walk/{start_id}
+│   │       └── bloom.py         # POST /autobloom/{node_id}
+│   ├── cli/                     # command-line interface
+│   │   ├── __init__.py
+│   │   └── commands.py          # click-based commands (init, load, dump, serve)
+│   ├── visualization/           # 3D layout & rendering helpers
+│   │   ├── __init__.py
+│   │   ├── coords_generator.py  # helix_coords(node, idx, total, …)
+│   │   └── threejs_renderer.py  # JSON export for Three.js front-end
+│   └── agents/                  # LLM/chatbot integrations & webhooks
+│       ├── __init__.py
+│       ├── chat_adapter.py      # ChatMessage → Graph operations
+│       └── webhook_listener.py  # HTTP hook into CI/CD, code-commit events
+├── frontend/                    # React + Three.js UI
 │   ├── package.json
+│   ├── public/
+│   │   └── index.html
 │   └── src/
-│       ├── App.jsx
-│       ├── GraphView.jsx
+│       ├── App.jsx              # root component
+│       ├── GraphView.jsx        # canvas + renderer
 │       └── services/
-│           └── hyperhelix_api.js
-├── tests/
-├── docs/
+│           └── hyperhelix_api.js# Axios calls to backend
+├── tests/                       # full unit & integration coverage
+│   ├── test_node.py
+│   ├── test_core.py
+│   ├── test_importance.py
+│   ├── test_permanence.py
+│   ├── test_evented_engine.py
+│   ├── test_continuous_engine.py
+│   ├── test_executor.py
+│   ├── test_tasks.py
+│   ├── test_persistence.py
+│   ├── test_api.py
+│   └── test_cli.py
+└── docs/                        # full documentation & tutorials
+    ├── architecture.md          # high-level system overview
+    ├── modules.md               # deep dive per module
+    └── tutorials/
+        ├── quick_start.md
+        ├── team_orchestration.md
+        └── advanced_evolution.md
 ```
 
 ## Module Responsibilities

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,0 +1,5 @@
+# Config Guidelines
+
+- `default.yaml` stores runtime tunables such as strands and thresholds.
+- `logging.yaml` defines log format and file paths. Ensure `hyperhelix.log` and `errors.log` remain writable.
+- `persistence.yaml` lists database connection details for available adapters.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,4 @@
+# Default runtime settings
+strands: 3
+thresholds:
+  importance: 0.5

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -1,0 +1,27 @@
+version: 1
+formatters:
+  standard:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: standard
+    level: INFO
+  file:
+    class: logging.FileHandler
+    formatter: standard
+    filename: hyperhelix.log
+    level: INFO
+  error_file:
+    class: logging.FileHandler
+    formatter: standard
+    filename: errors.log
+    level: ERROR
+loggers:
+  hyperhelix:
+    handlers: [console, file, error_file]
+    level: INFO
+    propagate: no
+root:
+  handlers: [console, file, error_file]
+  level: WARNING

--- a/config/persistence.yaml
+++ b/config/persistence.yaml
@@ -1,0 +1,9 @@
+# Persistence adapter configuration
+neo4j:
+  uri: bolt://localhost:7687
+  user: neo4j
+  password: changeme
+qdrant:
+  url: http://localhost:6333
+sqlalchemy:
+  url: sqlite:///hyperhelix.db

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,8 @@ Follow these steps to work with the full HelixHyper system:
 1. Clone the repository and install dependencies with `pip install -r requirements.txt` before starting any service or container.
 2. Adjust configuration in `config/` as needed, particularly `logging.yaml` for log levels and file locations.
 3. Run `pytest -q` to ensure the codebase imports and tests pass.
-4. Use the CLI or API components once implemented to interact with the graph, or build the included `Dockerfile` to run everything in a container.
+4. Use the CLI or API components to interact with the graph. The API exposes endpoints for creating nodes and edges and walking the graph.
+5. Build the included `Dockerfile` to run everything in a container if desired.
 
 Keep documentation up to date as new modules are added.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,17 @@
+# Build and Deployment Instructions
+
+Follow these steps to work with the full HelixHyper system:
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Adjust configuration in `config/` as needed, particularly `logging.yaml` for log levels and file locations.
+3. Run `pytest -q` to ensure the codebase imports and tests pass.
+4. Use the CLI or API components once implemented to interact with the graph.
+
+Keep documentation up to date as new modules are added.
+
+Configuration files include:
+- `default.yaml` for runtime settings like strand counts.
+- `persistence.yaml` for database connection details.
+Update these along with `logging.yaml` when deploying to new environments.
+For LLM integration set provider API keys (e.g. `OPENAI_API_KEY`) in the environment before running the application.
+Each package directory may also contain an `AGENTS.md` with specialized instructions.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,6 +4,7 @@ Follow these steps to work with the full HelixHyper system:
 
 1. Clone the repository and install dependencies with `pip install -r requirements.txt` before starting any service or container.
 2. Adjust configuration in `config/` as needed, particularly `logging.yaml` for log levels and file locations.
+   Logs are written to `hyperhelix.log` with errors duplicated in `errors.log`.
 3. Run `pytest -q` to ensure the codebase imports and tests pass.
 4. Use the CLI or API components to interact with the graph. The API exposes endpoints for creating nodes and edges and walking the graph.
 5. Build the included `Dockerfile` to run everything in a container if desired.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,10 +2,10 @@
 
 Follow these steps to work with the full HelixHyper system:
 
-1. Install dependencies with `pip install -r requirements.txt`.
+1. Clone the repository and install dependencies with `pip install -r requirements.txt` before starting any service or container.
 2. Adjust configuration in `config/` as needed, particularly `logging.yaml` for log levels and file locations.
 3. Run `pytest -q` to ensure the codebase imports and tests pass.
-4. Use the CLI or API components once implemented to interact with the graph.
+4. Use the CLI or API components once implemented to interact with the graph, or build the included `Dockerfile` to run everything in a container.
 
 Keep documentation up to date as new modules are added.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,4 +2,4 @@
 
 HelixHyper is organized around a graph of `Node` objects connected via weighted edges. Each node carries payload data and metadata about its creation and updates. The `HyperHelix` class manages these nodes and provides traversal helpers like `spiral_walk`.
 
-Subsystems include analytics for scoring nodes, evolution engines for automatic pruning and weaving, and persistence adapters for different databases. A FastAPI-based API exposes graph operations, while a lightweight CLI and React front-end provide additional interfaces.
+Subsystems include analytics for scoring nodes, evolution engines for automatic pruning and weaving, and persistence adapters for different databases. Event hooks respond to node updates, recalculating metrics or invoking custom tasks. A FastAPI-based API exposes graph operations, while a lightweight CLI and React front-end provide additional interfaces.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,5 @@
+# Architecture Overview
+
+HelixHyper is organized around a graph of `Node` objects connected via weighted edges. Each node carries payload data and metadata about its creation and updates. The `HyperHelix` class manages these nodes and provides traversal helpers like `spiral_walk`.
+
+Subsystems include analytics for scoring nodes, evolution engines for automatic pruning and weaving, and persistence adapters for different databases. A FastAPI-based API exposes graph operations, while a lightweight CLI and React front-end provide additional interfaces.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,3 +3,5 @@
 HelixHyper is organized around a graph of `Node` objects connected via weighted edges. Each node carries payload data and metadata about its creation and updates. The `HyperHelix` class manages these nodes and provides traversal helpers like `spiral_walk`.
 
 Subsystems include analytics for scoring nodes, evolution engines for automatic pruning and weaving, and persistence adapters for different databases. Event hooks respond to node updates, recalculating metrics or invoking custom tasks. A FastAPI-based API exposes graph operations, while a lightweight CLI and React front-end provide additional interfaces.
+
+The evolution layer continuously maintains graph health by pruning edges to removed nodes and linking new nodes with similar tags. Execution results are stored in each node's metadata so future analysis can learn from past runs.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -4,5 +4,8 @@
 - **hyperhelix/** – core engine and subpackages for analytics, evolution, execution and more.
 - **hyperhelix/api/** – FastAPI server exposing REST routes.
 - **hyperhelix/cli/** – command-line interface helpers.
+- **hyperhelix/evolution/** – event-driven and periodic engines that update node metrics.
 - **frontend/** – example React + Three.js client.
 - **tests/** – unit tests covering the system.
+
+Start the API from the command line with `python -m hyperhelix.cli.commands serve`.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,8 @@
+# Module Guide
+
+- **config/** – configuration files for runtime tuning, logging and persistence.
+- **hyperhelix/** – core engine and subpackages for analytics, evolution, execution and more.
+- **hyperhelix/api/** – FastAPI server exposing REST routes.
+- **hyperhelix/cli/** – command-line interface helpers.
+- **frontend/** – example React + Three.js client.
+- **tests/** – unit tests covering the system.

--- a/docs/tutorials/advanced_evolution.md
+++ b/docs/tutorials/advanced_evolution.md
@@ -1,0 +1,3 @@
+# Advanced Evolution
+
+Event-driven evolution hooks allow the graph to adjust itself whenever nodes or edges change. Customize the `evented_engine` module to prune outdated nodes or introduce new connections automatically.

--- a/docs/tutorials/advanced_evolution.md
+++ b/docs/tutorials/advanced_evolution.md
@@ -1,3 +1,9 @@
 # Advanced Evolution
 
 Event-driven evolution hooks allow the graph to adjust itself whenever nodes or edges change. Customize the `evented_engine` module to prune outdated nodes or introduce new connections automatically.
+
+The default implementation now performs several actions:
+
+- **Metric updates** recalculate importance and permanence on inserts and updates.
+- **Tag weaving** connects a newly inserted node to existing nodes that share tags.
+- **Pruning** removes edges pointing to nodes that no longer exist, keeping the graph healthy.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -1,0 +1,6 @@
+# Quick Start
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Run `pytest -q` to confirm the environment is healthy.
+3. Launch the API using `uvicorn hyperhelix.api.main:app --reload`.
+4. Use the provided HTTP routes to create nodes and edges.

--- a/docs/tutorials/team_orchestration.md
+++ b/docs/tutorials/team_orchestration.md
@@ -1,0 +1,3 @@
+# Team Orchestration
+
+The task manager submodule allows you to create and assign tasks to users. Nodes representing tasks can be linked to code changes or documentation to keep project planning within the same graph used for execution.

--- a/hyperhelix/AGENTS.md
+++ b/hyperhelix/AGENTS.md
@@ -1,0 +1,8 @@
+# HyperHelix Module Guidelines
+
+This package hosts the core graph engine. When extending modules keep the following in mind:
+
+- Maintain thread safety when modifying `HyperHelix` methods.
+- Always log actions using the `hyperhelix` logger configured at package import.
+- Avoid TODO comments in the code. Document future work in `docs/` or issues.
+- New modules should include unit tests under `tests/`.

--- a/hyperhelix/__init__.py
+++ b/hyperhelix/__init__.py
@@ -1,0 +1,15 @@
+import logging
+import logging.config
+from pathlib import Path
+import yaml
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / 'config' / 'logging.yaml'
+
+if CONFIG_PATH.exists():
+    with CONFIG_PATH.open('r') as f:
+        config = yaml.safe_load(f)
+    logging.config.dictConfig(config)
+else:
+    logging.basicConfig(level=logging.INFO)
+
+__all__ = ['core', 'node', 'edge', 'metadata']

--- a/hyperhelix/agents/AGENTS.md
+++ b/hyperhelix/agents/AGENTS.md
@@ -1,0 +1,3 @@
+# Agents Guidelines
+- Integrate chat interfaces and webhooks to update the graph.
+- Use `hyperhelix.agents.llm` for LLM interactions. Configure API keys via environment variables when using providers like OpenAI.

--- a/hyperhelix/agents/__init__.py
+++ b/hyperhelix/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Integrations for chat interfaces, webhooks and LLMs."""
+
+__all__ = [
+    "chat_adapter",
+    "webhook_listener",
+    "llm",
+]

--- a/hyperhelix/agents/chat_adapter.py
+++ b/hyperhelix/agents/chat_adapter.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from ..core import HyperHelix
+from ..node import Node
+from .llm import BaseChatModel
+
+
+def handle_chat_message(graph: HyperHelix, message: str, model: BaseChatModel | None = None) -> None:
+    """Store a chat message and optionally generate a reply using an LLM."""
+    node = Node(id=message, payload={"msg": message})
+    graph.add_node(node)
+    if model:
+        response = model.generate_response([
+            {"role": "user", "content": message},
+        ])
+        graph.add_node(Node(id=f"response:{message}", payload={"msg": response}))

--- a/hyperhelix/agents/llm.py
+++ b/hyperhelix/agents/llm.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import abc
+import logging
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class BaseChatModel(abc.ABC):
+    """Abstract interface for chat-based LLM providers."""
+
+    @abc.abstractmethod
+    def generate_response(self, messages: Sequence[dict]) -> str:
+        """Return a model-generated reply for the given messages."""
+
+
+class OpenAIChatModel(BaseChatModel):
+    """Simple OpenAI chat completion wrapper."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo", api_key: str | None = None) -> None:
+        import openai
+
+        self.client = openai.OpenAI(api_key=api_key)
+        self.model = model
+
+    def generate_response(self, messages: Sequence[dict]) -> str:
+        try:
+            resp = self.client.chat.completions.create(model=self.model, messages=list(messages))
+            return resp.choices[0].message.content
+        except Exception:  # pragma: no cover - network failures
+            logger.exception("LLM request failed")
+            raise

--- a/hyperhelix/agents/webhook_listener.py
+++ b/hyperhelix/agents/webhook_listener.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from ..core import HyperHelix
+from ..node import Node
+
+
+def process_webhook(graph: HyperHelix, payload: dict) -> None:
+    node_id = payload.get("id", "webhook")
+    graph.add_node(Node(id=node_id, payload=payload))

--- a/hyperhelix/analytics/AGENTS.md
+++ b/hyperhelix/analytics/AGENTS.md
@@ -1,0 +1,3 @@
+# Analytics Guidelines
+- Keep metric functions pure and testable.
+- Add unit tests for new algorithms.

--- a/hyperhelix/analytics/__init__.py
+++ b/hyperhelix/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for analyzing node importance and permanence."""

--- a/hyperhelix/analytics/importance.py
+++ b/hyperhelix/analytics/importance.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..node import Node
+
+
+def compute_importance(node: Node, all_nodes: Iterable[Node]) -> float:
+    """Compute node importance based on degree."""
+    return float(len(node.edges))

--- a/hyperhelix/analytics/permanence.py
+++ b/hyperhelix/analytics/permanence.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ..node import Node
+
+
+def compute_permanence(node: Node) -> float:
+    """Simple permanence metric based on age."""
+    age = (datetime.now(timezone.utc) - node.metadata.created).total_seconds()
+    return age

--- a/hyperhelix/api/AGENTS.md
+++ b/hyperhelix/api/AGENTS.md
@@ -1,0 +1,3 @@
+# API Guidelines
+- Use FastAPI to expose REST and GraphQL endpoints.
+- Validate input with Pydantic models.

--- a/hyperhelix/api/__init__.py
+++ b/hyperhelix/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application providing REST and GraphQL interfaces."""

--- a/hyperhelix/api/dependencies.py
+++ b/hyperhelix/api/dependencies.py
@@ -1,1 +1,10 @@
-"""Placeholder for authentication dependencies."""
+"""Common API dependencies."""
+
+from fastapi import Request
+
+from ..core import HyperHelix
+
+
+def get_graph(request: Request) -> HyperHelix:
+    """Return the app's graph instance."""
+    return request.app.state.graph

--- a/hyperhelix/api/dependencies.py
+++ b/hyperhelix/api/dependencies.py
@@ -1,0 +1,1 @@
+"""Placeholder for authentication dependencies."""

--- a/hyperhelix/api/main.py
+++ b/hyperhelix/api/main.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get('/')
+def read_root() -> dict[str, str]:
+    return {"status": "ok"}

--- a/hyperhelix/api/main.py
+++ b/hyperhelix/api/main.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from ..core import HyperHelix
+from .routers import nodes, edges, walk, bloom
+
 app = FastAPI()
+app.state.graph = HyperHelix()
+app.include_router(nodes.router)
+app.include_router(edges.router)
+app.include_router(walk.router)
+app.include_router(bloom.router)
 
 
 @app.get('/')

--- a/hyperhelix/api/routers/AGENTS.md
+++ b/hyperhelix/api/routers/AGENTS.md
@@ -1,0 +1,6 @@
+# API Routers Guidelines
+
+- Keep endpoints minimal and focused on graph operations.
+- Use `Depends(get_graph)` to access the shared graph.
+- Return Pydantic models for consistency across routes.
+- Add tests in `tests/` when introducing new endpoints.

--- a/hyperhelix/api/routers/__init__.py
+++ b/hyperhelix/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Route handlers for the API."""

--- a/hyperhelix/api/routers/bloom.py
+++ b/hyperhelix/api/routers/bloom.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from ..dependencies import get_graph
+from ...core import HyperHelix
+from ...node import Node
 
 router = APIRouter()
 
 
 @router.post('/autobloom/{node_id}')
-def auto_bloom(node_id: str) -> dict[str, str]:
+def auto_bloom(node_id: str, graph: HyperHelix = Depends(get_graph)) -> dict[str, str]:
+    graph.add_node(Node(id=f"bloom:{node_id}", payload={"source": node_id}))
     return {"node": node_id}

--- a/hyperhelix/api/routers/bloom.py
+++ b/hyperhelix/api/routers/bloom.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.post('/autobloom/{node_id}')
+def auto_bloom(node_id: str) -> dict[str, str]:
+    return {"node": node_id}

--- a/hyperhelix/api/routers/edges.py
+++ b/hyperhelix/api/routers/edges.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..schemas import EdgeIn
+from ..dependencies import get_graph
+from ...core import HyperHelix
 
 router = APIRouter()
 
 
 @router.post('/edges')
-def create_edge() -> dict[str, str]:
+def create_edge(edge: EdgeIn, graph: HyperHelix = Depends(get_graph)) -> dict[str, str]:
+    try:
+        graph.add_edge(edge.a, edge.b, edge.weight)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Node {exc.args[0]} not found")
     return {"status": "created"}

--- a/hyperhelix/api/routers/edges.py
+++ b/hyperhelix/api/routers/edges.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
+import logging
 
 from ..schemas import EdgeIn
 from ..dependencies import get_graph
 from ...core import HyperHelix
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post('/edges')
@@ -14,5 +16,6 @@ def create_edge(edge: EdgeIn, graph: HyperHelix = Depends(get_graph)) -> dict[st
     try:
         graph.add_edge(edge.a, edge.b, edge.weight)
     except KeyError as exc:
+        logger.error("Create edge failed missing node %s", exc.args[0])
         raise HTTPException(status_code=404, detail=f"Node {exc.args[0]} not found")
     return {"status": "created"}

--- a/hyperhelix/api/routers/edges.py
+++ b/hyperhelix/api/routers/edges.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.post('/edges')
+def create_edge() -> dict[str, str]:
+    return {"status": "created"}

--- a/hyperhelix/api/routers/nodes.py
+++ b/hyperhelix/api/routers/nodes.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from ..schemas import NodeIn
+
+router = APIRouter()
+
+
+@router.post('/nodes')
+def create_node(node: NodeIn) -> NodeIn:
+    return node

--- a/hyperhelix/api/routers/nodes.py
+++ b/hyperhelix/api/routers/nodes.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 
-from ..schemas import NodeIn
+from ..schemas import NodeIn, NodeOut
+from ..dependencies import get_graph
+from ...core import HyperHelix
+from ...node import Node
 
 router = APIRouter()
 
 
-@router.post('/nodes')
-def create_node(node: NodeIn) -> NodeIn:
-    return node
+@router.post('/nodes', response_model=NodeOut)
+def create_node(node: NodeIn, graph: HyperHelix = Depends(get_graph)) -> NodeOut:
+    if node.id in graph.nodes:
+        raise HTTPException(status_code=400, detail='Node exists')
+    g_node = Node(id=node.id, payload=node.payload)
+    graph.add_node(g_node)
+    return NodeOut(id=g_node.id, payload=g_node.payload)
+
+
+@router.get('/nodes/{node_id}', response_model=NodeOut)
+def get_node(node_id: str, graph: HyperHelix = Depends(get_graph)) -> NodeOut:
+    try:
+        node = graph.nodes[node_id]
+    except KeyError:
+        raise HTTPException(status_code=404, detail='Not found')
+    return NodeOut(id=node.id, payload=node.payload)

--- a/hyperhelix/api/routers/nodes.py
+++ b/hyperhelix/api/routers/nodes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
+import logging
 
 from ..schemas import NodeIn, NodeOut
 from ..dependencies import get_graph
@@ -8,11 +9,13 @@ from ...core import HyperHelix
 from ...node import Node
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post('/nodes', response_model=NodeOut)
 def create_node(node: NodeIn, graph: HyperHelix = Depends(get_graph)) -> NodeOut:
     if node.id in graph.nodes:
+        logger.error("Create node failed duplicate id %s", node.id)
         raise HTTPException(status_code=400, detail='Node exists')
     g_node = Node(id=node.id, payload=node.payload)
     graph.add_node(g_node)
@@ -24,5 +27,6 @@ def get_node(node_id: str, graph: HyperHelix = Depends(get_graph)) -> NodeOut:
     try:
         node = graph.nodes[node_id]
     except KeyError:
+        logger.error("Node %s not found", node_id)
         raise HTTPException(status_code=404, detail='Not found')
     return NodeOut(id=node.id, payload=node.payload)

--- a/hyperhelix/api/routers/walk.py
+++ b/hyperhelix/api/routers/walk.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get('/walk/{start_id}')
+def walk_graph(start_id: str) -> dict[str, str]:
+    return {"start": start_id}

--- a/hyperhelix/api/routers/walk.py
+++ b/hyperhelix/api/routers/walk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
+import logging
 from typing import List
 
 from ..schemas import NodeOut
@@ -8,6 +9,7 @@ from ..dependencies import get_graph
 from ...core import HyperHelix
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get('/walk/{start_id}', response_model=List[NodeOut])
@@ -15,5 +17,6 @@ def walk_graph(start_id: str, depth: int = 1, graph: HyperHelix = Depends(get_gr
     try:
         nodes = list(graph.spiral_walk(start_id, depth))
     except KeyError:
+        logger.error("Start node %s not found", start_id)
         raise HTTPException(status_code=404, detail='Start node not found')
     return [NodeOut(id=n.id, payload=n.payload) for n in nodes]

--- a/hyperhelix/api/schemas.py
+++ b/hyperhelix/api/schemas.py
@@ -4,5 +4,22 @@ from pydantic import BaseModel
 
 
 class NodeIn(BaseModel):
+    """Incoming node data."""
+
     id: str
     payload: dict
+
+
+class NodeOut(BaseModel):
+    """Node representation returned from the API."""
+
+    id: str
+    payload: dict
+
+
+class EdgeIn(BaseModel):
+    """Edge creation payload."""
+
+    a: str
+    b: str
+    weight: float = 1.0

--- a/hyperhelix/api/schemas.py
+++ b/hyperhelix/api/schemas.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class NodeIn(BaseModel):
+    id: str
+    payload: dict

--- a/hyperhelix/cli/AGENTS.md
+++ b/hyperhelix/cli/AGENTS.md
@@ -1,0 +1,2 @@
+# CLI Guidelines
+- Provide commands for initialization and serving the API.

--- a/hyperhelix/cli/__init__.py
+++ b/hyperhelix/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interface for local development."""

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -10,4 +10,7 @@ def cli() -> None:
 
 @cli.command()
 def serve() -> None:
-    click.echo("Serving API")
+    """Run the HTTP API using Uvicorn."""
+    import uvicorn
+
+    uvicorn.run("hyperhelix.api.main:app", host="0.0.0.0", port=8000)

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import click
+
+
+@click.group()
+def cli() -> None:
+    """Command-line interface entry point."""
+
+
+@cli.command()
+def serve() -> None:
+    click.echo("Serving API")

--- a/hyperhelix/core.py
+++ b/hyperhelix/core.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Dict, Generator
+
+import logging
+
+from .node import Node
+from .edge import connect
+
+logger = logging.getLogger(__name__)
+
+
+class HyperHelix:
+    def __init__(self) -> None:
+        self.nodes: Dict[str, Node] = {}
+
+    def add_node(self, node: Node) -> None:
+        logger.debug("Adding node %s", node.id)
+        self.nodes[node.id] = node
+
+    def add_edge(self, a: str, b: str, weight: float = 1.0) -> None:
+        logger.debug("Adding edge %s <-> %s", a, b)
+        try:
+            node_a = self.nodes[a]
+            node_b = self.nodes[b]
+        except KeyError as exc:  # pragma: no cover - run-time safeguard
+            logger.error("Cannot add edge, node missing: %s", exc.args[0])
+            raise
+        connect(node_a, node_b, weight)
+
+    def find_nodes_by_tag(self, tag: str) -> list[Node]:
+        """Return all nodes containing the given tag."""
+        logger.debug("Searching nodes with tag %s", tag)
+        return [n for n in self.nodes.values() if tag in n.tags]
+
+    def spiral_walk(self, start_id: str, depth: int = 1) -> Generator[Node, None, None]:
+        logger.debug("Spiral walk from %s depth %d", start_id, depth)
+        if start_id not in self.nodes:
+            logger.error("Start node %s not found", start_id)
+            raise KeyError(start_id)
+        visited = set()
+        queue = deque([(start_id, 0)])
+        while queue:
+            current_id, level = queue.popleft()
+            if current_id in visited or level > depth:
+                continue
+            visited.add(current_id)
+            node = self.nodes[current_id]
+            yield node
+            for neighbor_id in node.edges:
+                queue.append((neighbor_id, level + 1))

--- a/hyperhelix/edge.py
+++ b/hyperhelix/edge.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def connect(node_a, node_b, weight: float = 1.0) -> None:
+    """Create a bidirectional edge between two nodes."""
+    node_a.edges[node_b.id] = weight
+    node_b.edges[node_a.id] = weight
+    logger.debug("Connected %s <-> %s with weight %s", node_a.id, node_b.id, weight)

--- a/hyperhelix/evolution/AGENTS.md
+++ b/hyperhelix/evolution/AGENTS.md
@@ -1,0 +1,3 @@
+# Evolution Guidelines
+- Implement event-driven pruning and weaving.
+- Ensure thread safety when modifying the graph.

--- a/hyperhelix/evolution/__init__.py
+++ b/hyperhelix/evolution/__init__.py
@@ -1,0 +1,1 @@
+"""Event-driven engines that prune and weave the graph."""

--- a/hyperhelix/evolution/continuous_engine.py
+++ b/hyperhelix/evolution/continuous_engine.py
@@ -4,16 +4,19 @@ import threading
 import time
 
 from ..core import HyperHelix
+from ..analytics.importance import compute_importance
+from ..analytics.permanence import compute_permanence
 
 
 def run_periodically(graph: HyperHelix, interval: float) -> threading.Thread:
-    """Run a simple evolution pass at a fixed interval."""
+    """Periodically recompute node metrics."""
 
     def _worker() -> None:
         while True:
             time.sleep(interval)
-            # Placeholder for evolution logic
-            _ = len(graph.nodes)
+            for node in graph.nodes.values():
+                node.metadata.importance = compute_importance(node, graph.nodes.values())
+                node.metadata.permanence = compute_permanence(node)
 
     t = threading.Thread(target=_worker, daemon=True)
     t.start()

--- a/hyperhelix/evolution/continuous_engine.py
+++ b/hyperhelix/evolution/continuous_engine.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import threading
+import time
+
+from ..core import HyperHelix
+
+
+def run_periodically(graph: HyperHelix, interval: float) -> threading.Thread:
+    """Run a simple evolution pass at a fixed interval."""
+
+    def _worker() -> None:
+        while True:
+            time.sleep(interval)
+            # Placeholder for evolution logic
+            _ = len(graph.nodes)
+
+    t = threading.Thread(target=_worker, daemon=True)
+    t.start()
+    return t

--- a/hyperhelix/evolution/evented_engine.py
+++ b/hyperhelix/evolution/evented_engine.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from ..core import HyperHelix
+from ..analytics.importance import compute_importance
+from ..analytics.permanence import compute_permanence
 
 
 def on_insert(graph: HyperHelix, node_id: str) -> None:
-    """Example hook triggered when a node is inserted."""
-    # A real implementation could prune or weave the graph here.
-    _ = graph.nodes.get(node_id)
+    """Update metrics when a node is inserted."""
+    node = graph.nodes[node_id]
+    node.metadata.importance = compute_importance(node, graph.nodes.values())
+    node.metadata.permanence = compute_permanence(node)

--- a/hyperhelix/evolution/evented_engine.py
+++ b/hyperhelix/evolution/evented_engine.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from ..core import HyperHelix
+
+
+def on_insert(graph: HyperHelix, node_id: str) -> None:
+    """Example hook triggered when a node is inserted."""
+    # A real implementation could prune or weave the graph here.
+    _ = graph.nodes.get(node_id)

--- a/hyperhelix/evolution/evented_engine.py
+++ b/hyperhelix/evolution/evented_engine.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from ..core import HyperHelix
+from ..node import Node
+from ..edge import connect
 from ..analytics.importance import compute_importance
 from ..analytics.permanence import compute_permanence
 
@@ -8,5 +10,36 @@ from ..analytics.permanence import compute_permanence
 def on_insert(graph: HyperHelix, node_id: str) -> None:
     """Update metrics when a node is inserted."""
     node = graph.nodes[node_id]
+    _update_metrics(graph, node)
+    weave_by_tag(graph, node_id)
+    prune_missing_edges(graph)
+
+
+def on_update(graph: HyperHelix, node_id: str) -> None:
+    """Update metrics when a node changes."""
+    node = graph.nodes[node_id]
+    _update_metrics(graph, node)
+    prune_missing_edges(graph)
+
+
+def _update_metrics(graph: HyperHelix, node: "Node") -> None:
     node.metadata.importance = compute_importance(node, graph.nodes.values())
     node.metadata.permanence = compute_permanence(node)
+
+
+def weave_by_tag(graph: HyperHelix, node_id: str) -> None:
+    """Connect new node to existing nodes sharing tags."""
+    node = graph.nodes[node_id]
+    for tag in node.tags:
+        for other in graph.find_nodes_by_tag(tag):
+            if other.id != node.id and other.id not in node.edges:
+                connect(node, other)
+
+
+def prune_missing_edges(graph: HyperHelix) -> None:
+    """Remove edges pointing to nonexistent nodes."""
+    for node in list(graph.nodes.values()):
+        for neighbor_id in list(node.edges.keys()):
+            if neighbor_id not in graph.nodes:
+                del node.edges[neighbor_id]
+

--- a/hyperhelix/execution/AGENTS.md
+++ b/hyperhelix/execution/AGENTS.md
@@ -1,0 +1,3 @@
+# Execution Guidelines
+- Wrap external callables safely and log failures.
+- Provide hooks for recursion and task binding.

--- a/hyperhelix/execution/__init__.py
+++ b/hyperhelix/execution/__init__.py
@@ -1,0 +1,1 @@
+"""Wrappers and hooks for executing nodes."""

--- a/hyperhelix/execution/executor.py
+++ b/hyperhelix/execution/executor.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import logging
 
+from ..core import HyperHelix
 from ..node import Node
 
 logger = logging.getLogger(__name__)
 
 
-def execute_node(node: Node) -> None:
-    """Execute a node using its stored callable."""
+def execute_node(graph: HyperHelix, node_id: str) -> None:
+    """Execute a node and trigger update hooks."""
+    node = graph.nodes[node_id]
     try:
         node.execute()
     except Exception:
         logger.exception("Node %s execution failed", node.id)
         raise
+    for hook in graph._update_hooks:
+        hook(graph, node_id)

--- a/hyperhelix/execution/executor.py
+++ b/hyperhelix/execution/executor.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+from ..node import Node
+
+logger = logging.getLogger(__name__)
+
+
+def execute_node(node: Node) -> None:
+    """Execute a node using its stored callable."""
+    try:
+        node.execute()
+    except Exception:
+        logger.exception("Node %s execution failed", node.id)
+        raise

--- a/hyperhelix/execution/hook_manager.py
+++ b/hyperhelix/execution/hook_manager.py
@@ -6,6 +6,9 @@ from ..core import HyperHelix
 
 
 def bind_recursion_to_task(graph: HyperHelix, task: Callable[[], None]) -> None:
-    """Register a callback to be executed during graph evolution."""
-    # Simplified hook registration
-    task()
+    """Invoke ``task`` whenever a node is inserted."""
+
+    def _hook(_: HyperHelix, __: str) -> None:
+        task()
+
+    graph.register_insert_hook(_hook)

--- a/hyperhelix/execution/hook_manager.py
+++ b/hyperhelix/execution/hook_manager.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from ..core import HyperHelix
+
+
+def bind_recursion_to_task(graph: HyperHelix, task: Callable[[], None]) -> None:
+    """Register a callback to be executed during graph evolution."""
+    # Simplified hook registration
+    task()

--- a/hyperhelix/metadata.py
+++ b/hyperhelix/metadata.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import List
+
+
+@dataclass
+class NodeMetadata:
+    """Metadata about a node's lifecycle."""
+
+    created: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    updated: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    importance: float = 0.0
+    permanence: float = 0.0
+    perception_history: List[str] = field(default_factory=list)

--- a/hyperhelix/node.py
+++ b/hyperhelix/node.py
@@ -28,6 +28,8 @@ class Node:
             try:
                 result = self.execute_fn(self.payload)
                 logger.info("Node %s executed successfully", self.id)
+                if result is not None:
+                    self.metadata.perception_history.append(str(result))
                 return result
             except Exception:  # pragma: no cover - actual error path
                 logger.exception("Execution failed for node %s", self.id)

--- a/hyperhelix/node.py
+++ b/hyperhelix/node.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List
+
+from .metadata import NodeMetadata
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class Node:
+    id: str
+    payload: Any
+    tags: List[str] = field(default_factory=list)
+    layer: int = 0
+    strand: str = "default"
+    edges: Dict[str, float] = field(default_factory=dict)
+    metadata: NodeMetadata = field(default_factory=NodeMetadata)
+    execute_fn: Callable[[Any], Any] | None = None
+
+    def execute(self) -> Any:
+        logger.debug("Executing node %s", self.id)
+        self.metadata.updated = datetime.now(timezone.utc)
+        if self.execute_fn:
+            try:
+                result = self.execute_fn(self.payload)
+                logger.info("Node %s executed successfully", self.id)
+                return result
+            except Exception:  # pragma: no cover - actual error path
+                logger.exception("Execution failed for node %s", self.id)
+                raise
+        return None

--- a/hyperhelix/persistence/AGENTS.md
+++ b/hyperhelix/persistence/AGENTS.md
@@ -1,0 +1,3 @@
+# Persistence Guidelines
+- Implement adapters for Neo4j, Qdrant and SQLAlchemy.
+- Keep database settings in `config/persistence.yaml`.

--- a/hyperhelix/persistence/__init__.py
+++ b/hyperhelix/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Database adapters for storing nodes and edges."""

--- a/hyperhelix/persistence/base_adapter.py
+++ b/hyperhelix/persistence/base_adapter.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseAdapter(ABC):
+    @abstractmethod
+    def save_node(self, node_id: str, payload: dict) -> None: ...
+
+    @abstractmethod
+    def load_node(self, node_id: str) -> dict: ...

--- a/hyperhelix/persistence/neo4j_adapter.py
+++ b/hyperhelix/persistence/neo4j_adapter.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base_adapter import BaseAdapter
+
+
+class Neo4jAdapter(BaseAdapter):
+    """In-memory stand-in for a Neo4j adapter."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, dict] = {}
+
+    def save_node(self, node_id: str, payload: dict) -> None:
+        self._store[node_id] = payload
+
+    def load_node(self, node_id: str) -> dict:
+        return self._store[node_id]

--- a/hyperhelix/persistence/qdrant_adapter.py
+++ b/hyperhelix/persistence/qdrant_adapter.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .base_adapter import BaseAdapter
+
+
+class QdrantAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self._store: dict[str, dict] = {}
+
+    def save_node(self, node_id: str, payload: dict) -> None:
+        self._store[node_id] = payload
+
+    def load_node(self, node_id: str) -> dict:
+        return self._store[node_id]

--- a/hyperhelix/persistence/sqlalchemy_adapter.py
+++ b/hyperhelix/persistence/sqlalchemy_adapter.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .base_adapter import BaseAdapter
+
+
+class SQLAlchemyAdapter(BaseAdapter):
+    def __init__(self) -> None:
+        self._store: dict[str, dict] = {}
+
+    def save_node(self, node_id: str, payload: dict) -> None:
+        self._store[node_id] = payload
+
+    def load_node(self, node_id: str) -> dict:
+        return self._store[node_id]

--- a/hyperhelix/tasks/AGENTS.md
+++ b/hyperhelix/tasks/AGENTS.md
@@ -1,0 +1,3 @@
+# Tasks Guidelines
+- Manage project tasks as graph nodes.
+- Include tests for task utilities.

--- a/hyperhelix/tasks/__init__.py
+++ b/hyperhelix/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Project and sprint orchestration helpers."""

--- a/hyperhelix/tasks/sprint_planner.py
+++ b/hyperhelix/tasks/sprint_planner.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from ..core import HyperHelix
+
+
+def sprint_plan(graph: HyperHelix) -> list[str]:
+    """Return a simple ordered list of task IDs."""
+    return list(graph.nodes.keys())

--- a/hyperhelix/tasks/task.py
+++ b/hyperhelix/tasks/task.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Task:
+    id: str
+    description: str
+    due: Optional[datetime] = None
+    priority: int = 0
+    assigned_to: Optional[str] = None

--- a/hyperhelix/tasks/task_manager.py
+++ b/hyperhelix/tasks/task_manager.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from ..core import HyperHelix
+from ..node import Node
+from .task import Task
+
+
+def create_task(graph: HyperHelix, task: Task) -> None:
+    node = Node(id=task.id, payload=task)
+    graph.add_node(node)
+
+
+def assign_task(graph: HyperHelix, task_id: str, user: str) -> None:
+    node = graph.nodes[task_id]
+    if isinstance(node.payload, Task):
+        node.payload.assigned_to = user

--- a/hyperhelix/visualization/AGENTS.md
+++ b/hyperhelix/visualization/AGENTS.md
@@ -1,0 +1,2 @@
+# Visualization Guidelines
+- Generate 3D layouts for frontend consumption.

--- a/hyperhelix/visualization/__init__.py
+++ b/hyperhelix/visualization/__init__.py
@@ -1,0 +1,1 @@
+"""3D coordinate generation and rendering helpers."""

--- a/hyperhelix/visualization/coords_generator.py
+++ b/hyperhelix/visualization/coords_generator.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..node import Node
+
+
+def helix_coords(node: Node, idx: int, total: int) -> Tuple[float, float, float]:
+    """Generate simple 3D coordinates."""
+    angle = idx * 3.1415 * 2 / max(total, 1)
+    return (angle, idx, 0.0)

--- a/hyperhelix/visualization/threejs_renderer.py
+++ b/hyperhelix/visualization/threejs_renderer.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from ..node import Node
+
+
+def node_to_json(node: Node) -> dict:
+    return {"id": node.id, "payload": node.payload}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+pydantic
+SQLAlchemy
+neo4j
+qdrant-client
+PyYAML
+openai

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,4 @@
+# Testing Guidelines
+
+- Run `pytest -q` before committing changes.
+- Add new tests alongside new modules to keep coverage high.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+import sys
+
+# Ensure project root is on the path for imports when running `pytest`
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,13 @@
+from hyperhelix.core import HyperHelix
+from hyperhelix.agents.chat_adapter import handle_chat_message
+from hyperhelix.agents.llm import BaseChatModel
+
+class DummyModel(BaseChatModel):
+    def generate_response(self, messages):
+        return "reply"
+
+def test_handle_chat_message_with_model():
+    graph = HyperHelix()
+    handle_chat_message(graph, "hi", DummyModel())
+    assert "hi" in graph.nodes
+    assert "response:hi" in graph.nodes

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+import pytest
+from hyperhelix.api.main import app
+from hyperhelix.core import HyperHelix
+
+client = TestClient(app)
+
+@pytest.fixture(autouse=True)
+def reset_graph():
+    app.state.graph = HyperHelix()
+
+
+def test_create_and_get_node():
+    resp = client.post('/nodes', json={'id': 'a', 'payload': {'foo': 'bar'}})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['id'] == 'a'
+    resp = client.get('/nodes/a')
+    assert resp.status_code == 200
+    assert resp.json()['payload'] == {'foo': 'bar'}
+
+
+def test_create_edge_and_walk():
+    client.post('/nodes', json={'id': 'a', 'payload': {}})
+    client.post('/nodes', json={'id': 'b', 'payload': {}})
+    resp = client.post('/edges', json={'a': 'a', 'b': 'b'})
+    assert resp.status_code == 200
+    walk = client.get('/walk/a', params={'depth': 1})
+    assert walk.status_code == 200
+    ids = {n['id'] for n in walk.json()}
+    assert ids == {'a', 'b'}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,29 @@
+from hyperhelix.core import HyperHelix
+from hyperhelix.node import Node
+import pytest
+
+
+def test_add_and_walk():
+    graph = HyperHelix()
+    a = Node(id='a', payload=None)
+    b = Node(id='b', payload=None)
+    graph.add_node(a)
+    graph.add_node(b)
+    graph.add_edge('a', 'b')
+
+    nodes = list(graph.spiral_walk('a', depth=1))
+    ids = {n.id for n in nodes}
+    assert ids == {'a', 'b'}
+
+
+def test_add_edge_missing_node():
+    graph = HyperHelix()
+    graph.add_node(Node(id='a', payload=None))
+    with pytest.raises(KeyError):
+        graph.add_edge('a', 'missing')
+
+
+def test_spiral_walk_missing_start():
+    graph = HyperHelix()
+    with pytest.raises(KeyError):
+        list(graph.spiral_walk('missing'))

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,0 +1,34 @@
+import pytest
+from hyperhelix.core import HyperHelix
+from hyperhelix.node import Node
+from hyperhelix.execution.executor import execute_node
+from hyperhelix.evolution import evented_engine
+
+
+def test_weave_by_tag_on_insert():
+    g = HyperHelix()
+    g.add_node(Node(id="a", payload=None, tags=["x"]))
+    g.add_node(Node(id="b", payload=None, tags=["x"]))
+    # event hook registered automatically
+    assert "b" in g.nodes["a"].edges
+
+
+def test_prune_missing_edges():
+    g = HyperHelix()
+    a = Node(id="a", payload=None)
+    b = Node(id="b", payload=None)
+    g.add_node(a)
+    g.add_node(b)
+    g.add_edge("a", "b")
+    del g.nodes["b"]
+    evented_engine.prune_missing_edges(g)
+    assert "b" not in a.edges
+
+
+def test_execute_updates_hooks_and_history():
+    g = HyperHelix()
+    n = Node(id="x", payload=1, execute_fn=lambda p: p + 1)
+    g.add_node(n)
+    execute_node(g, "x")
+    assert n.metadata.perception_history == ["2"]
+

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -1,0 +1,11 @@
+from hyperhelix.core import HyperHelix
+from hyperhelix.node import Node
+
+
+def test_find_nodes_by_tag():
+    g = HyperHelix()
+    g.add_node(Node(id="a", payload=None, tags=["x"]))
+    g.add_node(Node(id="b", payload=None, tags=["y", "x"]))
+    res = g.find_nodes_by_tag("x")
+    ids = {n.id for n in res}
+    assert ids == {"a", "b"}

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,20 @@
+from hyperhelix.core import HyperHelix
+from hyperhelix.node import Node
+
+
+def test_register_insert_hook_called():
+    graph = HyperHelix()
+    called = {}
+
+    def hook(g: HyperHelix, node_id: str) -> None:
+        called['id'] = node_id
+
+    graph.register_insert_hook(hook)
+    graph.add_node(Node(id='x', payload=None))
+    assert called['id'] == 'x'
+
+
+def test_evented_engine_updates_metadata():
+    graph = HyperHelix()
+    graph.add_node(Node(id='a', payload=None))
+    assert graph.nodes['a'].metadata.permanence > 0

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,15 @@
+from hyperhelix.node import Node
+
+
+def test_node_execute():
+    called = {}
+
+    def run(payload):
+        called['result'] = payload
+        return payload
+
+    n = Node(id='1', payload={'a': 1}, execute_fn=run)
+    result = n.execute()
+    assert result == {'a': 1}
+    assert called['result'] == {'a': 1}
+    assert n.metadata.updated >= n.metadata.created


### PR DESCRIPTION
## Summary
- enhance Agents guidelines with LLM instructions
- support tag queries on graph nodes
- provide chat model abstraction with OpenAI wrapper
- integrate LLM responses in chat adapter
- include tests for new features

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c223277248331b3fde3e97162d177