### PR TITLE
Add nodes listing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ curl -X POST http://localhost:8000/nodes -H 'Content-Type: application/json' \
 curl -X POST http://localhost:8000/edges -H 'Content-Type: application/json' \
      -d '{"a": "a", "b": "b"}'
 
+curl http://localhost:8000/nodes
+
 curl http://localhost:8000/walk/a?depth=1
 
 # index project source

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,7 +6,7 @@ Follow these steps to work with the full HelixHyper system:
 2. Adjust configuration in `config/` as needed, particularly `logging.yaml` for log levels and file locations.
    Logs are written to `hyperhelix.log` with errors duplicated in `errors.log`.
 3. Run `pytest -q` to ensure the codebase imports and tests pass.
-4. Use the CLI or API components to interact with the graph. The API exposes endpoints for creating nodes and edges and walking the graph.
+4. Use the CLI or API components to interact with the graph. The API exposes endpoints for creating nodes and edges, listing nodes, and walking the graph.
 5. Build the included `Dockerfile` to run everything in a container if desired.
 
 Supply a persistence adapter when constructing `HyperHelix` if you need to

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -11,6 +11,7 @@
 - **hyperhelix/agents/code_scanner.py** – scans directories, stores Python source and links files via imports.
 - **hyperhelix/agents/llm.py** – wrappers for OpenAI and OpenRouter chat models.
 - **hyperhelix/api/routers/scan.py** – endpoint to index directories via `/scan`.
+- **hyperhelix/api/routers/nodes.py** – create, retrieve and list nodes.
 - **hyperhelix/api/routers/tasks.py** – CRUD operations for tasks.
 - **hyperhelix/api/routers/suggest.py** – get LLM-based code suggestions.
 - **hyperhelix/agents/llm.list_openrouter_models** – fetch available models.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -4,3 +4,4 @@
 2. Run `pytest -q` to confirm the environment is healthy.
 3. Launch the API using `uvicorn hyperhelix.api.main:app --reload`.
 4. Use the provided HTTP routes to create nodes and edges.
+5. Retrieve existing nodes with `curl http://localhost:8000/nodes`.

--- a/hyperhelix/api/routers/nodes.py
+++ b/hyperhelix/api/routers/nodes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException
+from typing import List
 import logging
 
 from ..schemas import NodeIn, NodeOut
@@ -30,3 +31,9 @@ def get_node(node_id: str, graph: HyperHelix = Depends(get_graph)) -> NodeOut:
         logger.error("Node %s not found", node_id)
         raise HTTPException(status_code=404, detail='Not found')
     return NodeOut(id=node.id, payload=node.payload)
+
+
+@router.get('/nodes', response_model=List[NodeOut])
+def list_nodes(graph: HyperHelix = Depends(get_graph)) -> list[NodeOut]:
+    """Return all nodes in the graph."""
+    return [NodeOut(id=n.id, payload=n.payload) for n in graph.nodes.values()]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,6 +72,15 @@ def test_get_missing_node():
     assert resp.status_code == 404
 
 
+def test_list_nodes():
+    client.post('/nodes', json={'id': 'a', 'payload': {}})
+    client.post('/nodes', json={'id': 'b', 'payload': {}})
+    resp = client.get('/nodes')
+    assert resp.status_code == 200
+    ids = {n['id'] for n in resp.json()}
+    assert ids == {'a', 'b'}
+
+
 def test_task_endpoints():
     resp = client.post('/tasks', json={'id': 't1', 'description': 'demo'})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add GET /nodes endpoint and test coverage
- document node listing in README and quick start guide
- update docs to include nodes router

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687de683a0848331b296fcc27a50eb47