### PR TITLE
Add CLI model listing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The graph core validates nodes when creating edges and logs an error if a refere
 The engine also provides event hooks. `evented_engine.on_insert` is registered automatically and recalculates importance and permanence whenever a node is added. You can register custom callbacks with `register_insert_hook` or `register_update_hook` to persist data or trigger other tasks.
 
 ## LLM Integration
-Use the helpers in `hyperhelix.agents.llm` to connect to popular language models such as OpenAI. Chat messages can be processed with `handle_chat_message`, which stores the conversation in the graph and records any model replies. Set provider keys like `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and `HUGGINGFACE_API_TOKEN` in the environment so integrations work correctly. When `OPENAI_API_KEY` isn’t present a fallback value of ``"test"`` is used so development can proceed without a real key.
+Use the helpers in `hyperhelix.agents.llm` to connect to popular language models such as OpenAI. Chat messages can be processed with `handle_chat_message`, which stores the conversation in the graph and records any model replies. Set provider keys like `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and `HUGGINGFACE_API_TOKEN` in the environment so integrations work correctly. When `OPENAI_API_KEY` isn’t present a fallback value of ``"test"`` is used so development can proceed without a real key. The convenience function `hyperhelix.utils.get_api_key("OPENROUTER_API_KEY")` retrieves keys with a warning if they are missing.
 
 ### Calling OpenAI directly
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"hug
 # use a local Transformers model
 curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"local"}'
 curl http://localhost:8000/models/huggingface?q=gpt2
+curl -X POST http://localhost:8000/chat -d '{"prompt":"Hello"}'
 ```
 ```
 hyperhelix_system/
@@ -187,7 +188,8 @@ hyperhelix_system/
 │   │       ├── suggest.py       # POST /suggest
 │   │       ├── models.py        # GET /models/openrouter
 │   │       ├── summary.py       # GET /summary
-│   │       └── export.py        # GET /export
+│   │       ├── export.py        # GET /export
+│   │       └── chat.py          # POST /chat
 │   ├── cli/                     # command-line interface
 │   │   ├── __init__.py
 │   │   └── commands.py          # click-based commands (init, load, dump, serve)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Quickly get an LLM response using:
 python -m hyperhelix.cli.commands codex "Hello" --provider openrouter
 python -m hyperhelix.cli.commands codex "Hello" --provider local
 python -m hyperhelix.cli.commands codex "Hi" --provider openrouter --model openai/gpt-4o --stream
+# the codex command also sends a graph summary as context
 python -m hyperhelix.cli.commands models --provider openrouter
 python -m hyperhelix.cli.commands models --provider huggingface --query gpt2
 python -m hyperhelix.cli.commands export graph.json
@@ -133,6 +134,7 @@ curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"hug
 curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"local"}'
 curl http://localhost:8000/models/huggingface?q=gpt2
 curl -X POST http://localhost:8000/chat -d '{"prompt":"Hello"}'
+# includes a graph summary automatically
 ```
 ```
 hyperhelix_system/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ python -m hyperhelix.cli.commands models --provider openrouter
 python -m hyperhelix.cli.commands models --provider huggingface --query gpt2
 python -m hyperhelix.cli.commands export graph.json
 ```
-The command reads `OPENROUTER_API_KEY` or `HUGGINGFACE_API_TOKEN` from the environment when contacting each provider.
+Commands read provider keys such as `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and
+`HUGGINGFACE_API_TOKEN` from the environment using
+`hyperhelix.utils.get_api_key()`.
 
 The `HyperHelix` graph accepts a persistence adapter for automatically storing
 nodes and edges. Instantiate it with an adapter such as `Neo4jAdapter` to

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Quickly get an LLM response using:
 python -m hyperhelix.cli.commands codex "Hello" --provider openrouter
 python -m hyperhelix.cli.commands codex "Hello" --provider local
 python -m hyperhelix.cli.commands codex "Hi" --provider openrouter --model openai/gpt-4o --stream
+python -m hyperhelix.cli.commands models --provider openrouter
+python -m hyperhelix.cli.commands models --provider huggingface --query gpt2
 ```
 
 The `HyperHelix` graph accepts a persistence adapter for automatically storing

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ python -m hyperhelix.cli.commands codex "Hi" --provider openrouter --model opena
 python -m hyperhelix.cli.commands models --provider openrouter
 python -m hyperhelix.cli.commands models --provider huggingface --query gpt2
 ```
+Listing models from OpenRouter requires the `OPENROUTER_API_KEY` environment variable.
 
 The `HyperHelix` graph accepts a persistence adapter for automatically storing
 nodes and edges. Instantiate it with an adapter such as `Neo4jAdapter` to

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ python -m hyperhelix.cli.commands codex "Hello" --provider local
 python -m hyperhelix.cli.commands codex "Hi" --provider openrouter --model openai/gpt-4o --stream
 python -m hyperhelix.cli.commands models --provider openrouter
 python -m hyperhelix.cli.commands models --provider huggingface --query gpt2
+python -m hyperhelix.cli.commands export graph.json
 ```
 The command reads `OPENROUTER_API_KEY` or `HUGGINGFACE_API_TOKEN` from the environment when contacting each provider.
 
@@ -183,7 +184,8 @@ hyperhelix_system/
 │   │       ├── tasks.py         # POST /tasks
 │   │       ├── suggest.py       # POST /suggest
 │   │       ├── models.py        # GET /models/openrouter
-│   │       └── summary.py       # GET /summary
+│   │       ├── summary.py       # GET /summary
+│   │       └── export.py        # GET /export
 │   ├── cli/                     # command-line interface
 │   │   ├── __init__.py
 │   │   └── commands.py          # click-based commands (init, load, dump, serve)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ python -m hyperhelix.cli.commands codex "Hi" --provider openrouter --model opena
 python -m hyperhelix.cli.commands models --provider openrouter
 python -m hyperhelix.cli.commands models --provider huggingface --query gpt2
 ```
-Listing models from OpenRouter requires the `OPENROUTER_API_KEY` environment variable.
+The command reads `OPENROUTER_API_KEY` or `HUGGINGFACE_API_TOKEN` from the environment when contacting each provider.
 
 The `HyperHelix` graph accepts a persistence adapter for automatically storing
 nodes and edges. Instantiate it with an adapter such as `Neo4jAdapter` to
@@ -294,6 +294,7 @@ from hyperhelix.agents.llm import list_openrouter_models
 models = list_openrouter_models()
 print(models)
 ```
+The helper reads `OPENROUTER_API_KEY` from the environment when available.
 Alternatively, call `GET /models/openrouter` to fetch the list via the API:
 
 ```bash
@@ -304,10 +305,11 @@ curl http://localhost:8000/models/openrouter
 
 ```python
 from hyperhelix.agents.llm import HuggingFaceChatModel
-model = HuggingFaceChatModel(api_key=os.getenv('HUGGINGFACE_API_TOKEN'))
+model = HuggingFaceChatModel()
 resp = model.generate_response([{'role': 'user', 'content': 'Hello'}])
 print(resp)
 ```
+The model reads `HUGGINGFACE_API_TOKEN` from the environment when present.
 
 ## Contribution Guidelines
 - Follow the structure above when adding modules.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,7 +17,7 @@
 - **hyperhelix/api/routers/models.py** – list available OpenRouter or HuggingFace models.
 - **hyperhelix/api/routers/summary.py** – return a graph summary via `/summary`.
 - **hyperhelix/api/routers/export.py** – dump the entire graph with `/export`.
-- **hyperhelix/api/routers/chat.py** – return raw LLM completions via `/chat`.
+- **hyperhelix/api/routers/chat.py** – return LLM completions with a graph summary via `/chat`.
 - **hyperhelix/api/routers/tasks.py** – CRUD operations for tasks.
 - **hyperhelix/api/routers/suggest.py** – get LLM-based code suggestions.
  - **hyperhelix/agents/llm.list_openrouter_models** – fetch OpenRouter models.
@@ -30,6 +30,7 @@ Use `python -m hyperhelix.cli.commands scan .` to index a directory.
 List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
+The `codex` command automatically includes a graph summary in the prompt.
 List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
 Commands read API keys such as `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and `HUGGINGFACE_API_TOKEN` from the environment. Use `hyperhelix.utils.get_api_key()` when accessing keys in your own scripts.
 Export the current graph with `python -m hyperhelix.cli.commands export graph.json`.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -14,8 +14,9 @@
 - **hyperhelix/api/routers/scan.py** – endpoint to index directories via `/scan`.
 - **hyperhelix/api/routers/nodes.py** – create, retrieve, list, delete and execute nodes.
 - **hyperhelix/api/routers/edges.py** – create, delete and list edges (global or by node).
- - **hyperhelix/api/routers/models.py** – list available OpenRouter or HuggingFace models.
+- **hyperhelix/api/routers/models.py** – list available OpenRouter or HuggingFace models.
 - **hyperhelix/api/routers/summary.py** – return a graph summary via `/summary`.
+- **hyperhelix/api/routers/export.py** – dump the entire graph with `/export`.
 - **hyperhelix/api/routers/tasks.py** – CRUD operations for tasks.
 - **hyperhelix/api/routers/suggest.py** – get LLM-based code suggestions.
  - **hyperhelix/agents/llm.list_openrouter_models** – fetch OpenRouter models.
@@ -30,3 +31,4 @@ Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
 List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
 The command reads provider keys like `OPENROUTER_API_KEY` from the environment. Use `hyperhelix.utils.get_api_key()` when accessing keys in your own scripts.
+Export the current graph with `python -m hyperhelix.cli.commands export graph.json`.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,6 +17,7 @@
 - **hyperhelix/api/routers/models.py** – list available OpenRouter or HuggingFace models.
 - **hyperhelix/api/routers/summary.py** – return a graph summary via `/summary`.
 - **hyperhelix/api/routers/export.py** – dump the entire graph with `/export`.
+- **hyperhelix/api/routers/chat.py** – return raw LLM completions via `/chat`.
 - **hyperhelix/api/routers/tasks.py** – CRUD operations for tasks.
 - **hyperhelix/api/routers/suggest.py** – get LLM-based code suggestions.
  - **hyperhelix/agents/llm.list_openrouter_models** – fetch OpenRouter models.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,3 +29,4 @@ List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
 List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
+Ensure `OPENROUTER_API_KEY` is configured for OpenRouter listings.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -30,5 +30,5 @@ List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
 List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
-The command reads provider keys like `OPENROUTER_API_KEY` from the environment. Use `hyperhelix.utils.get_api_key()` when accessing keys in your own scripts.
+Commands read API keys such as `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and `HUGGINGFACE_API_TOKEN` from the environment. Use `hyperhelix.utils.get_api_key()` when accessing keys in your own scripts.
 Export the current graph with `python -m hyperhelix.cli.commands export graph.json`.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -28,3 +28,4 @@ Use `python -m hyperhelix.cli.commands scan .` to index a directory.
 List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
+List models with `python -m hyperhelix.cli.commands models --provider openrouter`.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@ List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
 List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
-The command reads provider keys like `OPENROUTER_API_KEY` from the environment.
+The command reads provider keys like `OPENROUTER_API_KEY` from the environment. Use `hyperhelix.utils.get_api_key()` when accessing keys in your own scripts.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -29,4 +29,4 @@ List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hi"`.
 Specify a model and stream output with `python -m hyperhelix.cli.commands codex "Hi" --model openai/gpt-4o --stream`.
 List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
-Ensure `OPENROUTER_API_KEY` is configured for OpenRouter listings.
+The command reads provider keys like `OPENROUTER_API_KEY` from the environment.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -22,3 +22,4 @@
 20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
 21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
     Provider keys such as `OPENROUTER_API_KEY` are read from the environment. Use `hyperhelix.utils.get_api_key()` to fetch them in your own scripts.
+22. Export the graph with `python -m hyperhelix.cli.commands export graph.json` and inspect the resulting file.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -17,11 +17,12 @@
 15. Use HuggingFace with `curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"huggingface"}'`.
 16. Use a local model with `curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"local"}'`.
 17. List HuggingFace models with `curl http://localhost:8000/models/huggingface?q=gpt2`.
-18. List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
-19. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
-20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
-21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
+18. Send a raw chat request with `curl -X POST http://localhost:8000/chat -d '{"prompt":"Hi"}'`.
+19. List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
+20. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
+21. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
+22. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
     Commands read provider keys like `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and
     `HUGGINGFACE_API_TOKEN` from the environment via
     `hyperhelix.utils.get_api_key()`.
-22. Export the graph with `python -m hyperhelix.cli.commands export graph.json` and inspect the resulting file.
+23. Export the graph with `python -m hyperhelix.cli.commands export graph.json` and inspect the resulting file.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -21,5 +21,7 @@
 19. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
 20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
 21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
-    Provider keys such as `OPENROUTER_API_KEY` are read from the environment. Use `hyperhelix.utils.get_api_key()` to fetch them in your own scripts.
+    Commands read provider keys like `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and
+    `HUGGINGFACE_API_TOKEN` from the environment via
+    `hyperhelix.utils.get_api_key()`.
 22. Export the graph with `python -m hyperhelix.cli.commands export graph.json` and inspect the resulting file.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -20,3 +20,4 @@
 18. List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 19. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
 20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
+21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -17,7 +17,8 @@
 15. Use HuggingFace with `curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"huggingface"}'`.
 16. Use a local model with `curl -X POST http://localhost:8000/suggest -d '{"prompt":"Hello","provider":"local"}'`.
 17. List HuggingFace models with `curl http://localhost:8000/models/huggingface?q=gpt2`.
-18. Send a raw chat request with `curl -X POST http://localhost:8000/chat -d '{"prompt":"Hi"}'`.
+18. Send a chat request with `curl -X POST http://localhost:8000/chat -d '{"prompt":"Hi"}'`.
+    The server adds a short graph summary to the prompt automatically.
 19. List GitHub issues with `python -m hyperhelix.cli.commands issues owner/repo`.
 20. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
 21. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -21,4 +21,4 @@
 19. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
 20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
 21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
-    Provider keys such as `OPENROUTER_API_KEY` are read from the environment.
+    Provider keys such as `OPENROUTER_API_KEY` are read from the environment. Use `hyperhelix.utils.get_api_key()` to fetch them in your own scripts.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -21,4 +21,4 @@
 19. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
 20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
 21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
-    The command requires `OPENROUTER_API_KEY` to be set.
+    Provider keys such as `OPENROUTER_API_KEY` are read from the environment.

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -21,3 +21,4 @@
 19. Get an LLM reply using `python -m hyperhelix.cli.commands codex "Hello"`.
 20. Stream a response with `python -m hyperhelix.cli.commands codex "Hi" --stream --model openai/gpt-4o`.
 21. List models with `python -m hyperhelix.cli.commands models --provider openrouter`.
+    The command requires `OPENROUTER_API_KEY` to be set.

--- a/hyperhelix/__init__.py
+++ b/hyperhelix/__init__.py
@@ -12,4 +12,4 @@ if CONFIG_PATH.exists():
 else:
     logging.basicConfig(level=logging.INFO)  # pragma: no cover
 
-__all__ = ['core', 'node', 'edge', 'metadata']
+__all__ = ['core', 'node', 'edge', 'metadata', 'utils']

--- a/hyperhelix/agents/llm.py
+++ b/hyperhelix/agents/llm.py
@@ -27,10 +27,10 @@ class OpenAIChatModel(BaseChatModel):
         ``RuntimeError`` so tests can monkeypatch ``generate_response`` without
         actually hitting the API.
         """
-        import os
+        from ..utils import get_api_key
         import openai
 
-        key = api_key or os.getenv("OPENAI_API_KEY", "test")
+        key = api_key or get_api_key("OPENAI_API_KEY", "test")
         self.client = openai.OpenAI(api_key=key)
         self.model = model
 
@@ -47,12 +47,12 @@ class OpenRouterChatModel(BaseChatModel):
     """Chat model that calls the OpenRouter API."""
 
     def __init__(self, model: str = "openai/gpt-4o", api_key: str | None = None) -> None:
-        import os
+        from ..utils import get_api_key
         import httpx  # locally imported to ease mocking in tests
 
         self.httpx = httpx
         self.model = model
-        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY", "test")
+        self.api_key = api_key or get_api_key("OPENROUTER_API_KEY", "test")
 
     def generate_response(self, messages: Sequence[dict]) -> str:
         headers = {
@@ -112,12 +112,12 @@ class HuggingFaceChatModel(BaseChatModel):
     """Use the Hugging Face Inference API for chat completions."""
 
     def __init__(self, model: str = "HuggingFaceH4/zephyr-7b-beta", api_key: str | None = None) -> None:
-        import os
+        from ..utils import get_api_key
         import httpx  # imported locally for easier mocking
 
         self.httpx = httpx
         self.model = model
-        self.api_key = api_key or os.getenv("HUGGINGFACE_API_TOKEN")
+        self.api_key = api_key or get_api_key("HUGGINGFACE_API_TOKEN")
 
     def generate_response(self, messages: Sequence[dict]) -> str:
         prompt = "\n".join(m["content"] for m in messages)
@@ -161,10 +161,10 @@ class TransformersChatModel(BaseChatModel):
 
 def list_openrouter_models(api_key: str | None = None) -> list[str]:
     """Return a list of available model IDs from OpenRouter."""
-    import os
+    from ..utils import get_api_key
     import httpx
 
-    key = api_key or os.getenv("OPENROUTER_API_KEY")
+    key = api_key or get_api_key("OPENROUTER_API_KEY")
     headers = {"Authorization": f"Bearer {key}"} if key else {}
     try:
         resp = httpx.get(

--- a/hyperhelix/agents/llm.py
+++ b/hyperhelix/agents/llm.py
@@ -47,11 +47,12 @@ class OpenRouterChatModel(BaseChatModel):
     """Chat model that calls the OpenRouter API."""
 
     def __init__(self, model: str = "openai/gpt-4o", api_key: str | None = None) -> None:
+        import os
         import httpx  # locally imported to ease mocking in tests
 
         self.httpx = httpx
         self.model = model
-        self.api_key = api_key
+        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY", "test")
 
     def generate_response(self, messages: Sequence[dict]) -> str:
         headers = {
@@ -111,11 +112,12 @@ class HuggingFaceChatModel(BaseChatModel):
     """Use the Hugging Face Inference API for chat completions."""
 
     def __init__(self, model: str = "HuggingFaceH4/zephyr-7b-beta", api_key: str | None = None) -> None:
+        import os
         import httpx  # imported locally for easier mocking
 
         self.httpx = httpx
         self.model = model
-        self.api_key = api_key
+        self.api_key = api_key or os.getenv("HUGGINGFACE_API_TOKEN")
 
     def generate_response(self, messages: Sequence[dict]) -> str:
         prompt = "\n".join(m["content"] for m in messages)
@@ -159,9 +161,11 @@ class TransformersChatModel(BaseChatModel):
 
 def list_openrouter_models(api_key: str | None = None) -> list[str]:
     """Return a list of available model IDs from OpenRouter."""
+    import os
     import httpx
 
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    key = api_key or os.getenv("OPENROUTER_API_KEY")
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
     try:
         resp = httpx.get(
             "https://openrouter.ai/api/v1/models",

--- a/hyperhelix/api/main.py
+++ b/hyperhelix/api/main.py
@@ -11,6 +11,7 @@ from .routers import (
     scan,
     tasks,
     suggest,
+    chat,
     models,
     summary,
     export,
@@ -25,6 +26,7 @@ app.include_router(bloom.router)
 app.include_router(scan.router)
 app.include_router(tasks.router)
 app.include_router(suggest.router)
+app.include_router(chat.router)
 app.include_router(models.router)
 app.include_router(summary.router)
 app.include_router(export.router)

--- a/hyperhelix/api/main.py
+++ b/hyperhelix/api/main.py
@@ -13,6 +13,7 @@ from .routers import (
     suggest,
     models,
     summary,
+    export,
 )
 
 app = FastAPI()
@@ -26,6 +27,7 @@ app.include_router(tasks.router)
 app.include_router(suggest.router)
 app.include_router(models.router)
 app.include_router(summary.router)
+app.include_router(export.router)
 
 
 @app.get('/')

--- a/hyperhelix/api/routers/chat.py
+++ b/hyperhelix/api/routers/chat.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, HTTPException
+
+from ...agents.llm import (
+    OpenAIChatModel,
+    OpenRouterChatModel,
+    HuggingFaceChatModel,
+    TransformersChatModel,
+)
+from ...utils import get_api_key
+
+router = APIRouter()
+
+
+@router.post('/chat')
+def chat(prompt: str = Body(..., embed=True), provider: str = Body('openai'), model: str | None = Body(None)) -> dict[str, str]:
+    """Return a raw LLM response without graph context."""
+    if provider == 'openai':
+        llm = OpenAIChatModel(model=model or 'gpt-3.5-turbo', api_key=get_api_key('OPENAI_API_KEY', 'test'))
+    elif provider == 'openrouter':
+        llm = OpenRouterChatModel(model=model or 'openai/gpt-4o', api_key=get_api_key('OPENROUTER_API_KEY'))
+    elif provider in {'hf', 'huggingface'}:
+        llm = HuggingFaceChatModel(model=model or 'HuggingFaceH4/zephyr-7b-beta', api_key=get_api_key('HUGGINGFACE_API_TOKEN'))
+    elif provider in {'local', 'transformers'}:
+        llm = TransformersChatModel(model=model or 'sshleifer/tiny-gpt2')
+    else:
+        raise HTTPException(status_code=400, detail='Unknown provider')
+    response = llm.generate_response([{'role': 'user', 'content': prompt}])
+    return {'response': response}

--- a/hyperhelix/api/routers/export.py
+++ b/hyperhelix/api/routers/export.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..dependencies import get_graph
+from ...core import HyperHelix
+from ...visualization.threejs_renderer import node_to_json
+
+router = APIRouter()
+
+
+@router.get('/export')
+def export_graph(graph: HyperHelix = Depends(get_graph)) -> dict:
+    """Return the full graph as a JSON payload."""
+    nodes = [node_to_json(n) for n in graph.nodes.values()]
+    edges = [
+        {'a': a, 'b': b, 'weight': w}
+        for a, node in graph.nodes.items()
+        for b, w in node.edges.items()
+        if a < b
+    ]
+    return {'nodes': nodes, 'edges': edges}

--- a/hyperhelix/api/routers/models.py
+++ b/hyperhelix/api/routers/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import logging
 from fastapi import APIRouter, HTTPException
 from typing import List
@@ -14,7 +13,9 @@ logger = logging.getLogger(__name__)
 @router.get('/models/openrouter', response_model=List[str])
 def get_openrouter_models() -> list[str]:
     """Return available model identifiers from OpenRouter."""
-    api_key = os.getenv('OPENROUTER_API_KEY')
+    from ...utils import get_api_key
+
+    api_key = get_api_key('OPENROUTER_API_KEY')
     if not api_key:
         logger.error('OPENROUTER_API_KEY not set')
         raise HTTPException(status_code=503, detail='OPENROUTER_API_KEY not set')

--- a/hyperhelix/api/routers/suggest.py
+++ b/hyperhelix/api/routers/suggest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from fastapi import APIRouter, Depends, Body, HTTPException
 
 from ..dependencies import get_graph
@@ -11,6 +10,7 @@ from ...agents.llm import (
     HuggingFaceChatModel,
     TransformersChatModel,
 )
+from ...utils import get_api_key
 from ...agents.context import graph_summary
 
 router = APIRouter()
@@ -24,13 +24,19 @@ def suggest(
     graph: HyperHelix = Depends(get_graph),
 ) -> dict[str, str]:
     if provider == 'openai':
-        llm = OpenAIChatModel(model=model or 'gpt-3.5-turbo', api_key=os.getenv('OPENAI_API_KEY'))
+        llm = OpenAIChatModel(
+            model=model or 'gpt-3.5-turbo',
+            api_key=get_api_key('OPENAI_API_KEY', 'test'),
+        )
     elif provider == 'openrouter':
-        llm = OpenRouterChatModel(model=model or 'openai/gpt-4o', api_key=os.getenv('OPENROUTER_API_KEY'))
+        llm = OpenRouterChatModel(
+            model=model or 'openai/gpt-4o',
+            api_key=get_api_key('OPENROUTER_API_KEY'),
+        )
     elif provider in {'hf', 'huggingface'}:
         llm = HuggingFaceChatModel(
             model=model or 'HuggingFaceH4/zephyr-7b-beta',
-            api_key=os.getenv('HUGGINGFACE_API_TOKEN'),
+            api_key=get_api_key('HUGGINGFACE_API_TOKEN'),
         )
     elif provider in {'local', 'transformers'}:
         llm = TransformersChatModel(model=model or 'sshleifer/tiny-gpt2')

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -84,3 +84,27 @@ def codex(prompt: str, provider: str, model: str | None, stream: bool) -> None:
         response = chat.generate_response([{"role": "user", "content": prompt}])
 
     click.echo(response)
+
+
+@cli.command()
+@click.option(
+    "--provider",
+    type=click.Choice(["openrouter", "huggingface"], case_sensitive=False),
+    default="openrouter",
+    show_default=True,
+)
+@click.option("--query", "-q", default="gpt2", show_default=True, help="Search term for HuggingFace")
+@click.option("--limit", "-n", default=5, show_default=True, help="Number of HuggingFace models")
+def models(provider: str, query: str, limit: int) -> None:
+    """List available model identifiers."""
+    from ..agents import llm
+
+    provider = provider.lower()
+    if provider == "openrouter":
+        model_list = llm.list_openrouter_models(
+            api_key=os.getenv("OPENROUTER_API_KEY")
+        )
+    else:
+        model_list = llm.list_huggingface_models(search=query, limit=limit)
+    for mid in model_list:
+        click.echo(mid)

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -117,3 +117,30 @@ def models(provider: str, query: str, limit: int) -> None:
 
     for mid in model_list:
         click.echo(mid)
+
+
+@cli.command()
+@click.argument("output", default="-")
+def export(output: str) -> None:
+    """Export the current graph as JSON."""
+    from ..api.main import app
+    from ..visualization.threejs_renderer import node_to_json
+    import json
+    from pathlib import Path
+
+    graph = app.state.graph
+    data = {
+        "nodes": [node_to_json(n) for n in graph.nodes.values()],
+        "edges": [
+            {"a": a, "b": b, "weight": w}
+            for a, node in graph.nodes.items()
+            for b, w in node.edges.items()
+            if a < b
+        ],
+    }
+    text = json.dumps(data)
+    if output == "-":
+        click.echo(text)
+    else:
+        Path(output).write_text(text)
+        click.echo(f"Exported to {output}")

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -60,23 +60,29 @@ def codex(prompt: str, provider: str, model: str | None, stream: bool) -> None:
 
     provider = provider.lower()
     if provider == "openai":
+        from ..utils import get_api_key
+
         chat = llm.OpenAIChatModel(
-            model=model or "gpt-3.5-turbo", api_key=os.getenv("OPENAI_API_KEY")
+            model=model or "gpt-3.5-turbo", api_key=get_api_key("OPENAI_API_KEY")
         )
         response = chat.generate_response([{"role": "user", "content": prompt}])
     elif provider == "openrouter":
+        from ..utils import get_api_key
+
         chat = llm.OpenRouterChatModel(
             model=model or "openai/gpt-4o",
-            api_key=os.getenv("OPENROUTER_API_KEY"),
+            api_key=get_api_key("OPENROUTER_API_KEY") or "test",
         )
         if stream:
             response = chat.stream_response([{"role": "user", "content": prompt}])
         else:
             response = chat.generate_response([{"role": "user", "content": prompt}])
     elif provider == "huggingface":
+        from ..utils import get_api_key
+
         chat = llm.HuggingFaceChatModel(
             model=model or "HuggingFaceH4/zephyr-7b-beta",
-            api_key=os.getenv("HUGGINGFACE_API_TOKEN"),
+            api_key=get_api_key("HUGGINGFACE_API_TOKEN"),
         )
         response = chat.generate_response([{"role": "user", "content": prompt}])
     else:

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -100,11 +100,18 @@ def models(provider: str, query: str, limit: int) -> None:
     from ..agents import llm
 
     provider = provider.lower()
-    if provider == "openrouter":
-        model_list = llm.list_openrouter_models(
-            api_key=os.getenv("OPENROUTER_API_KEY")
-        )
-    else:
-        model_list = llm.list_huggingface_models(search=query, limit=limit)
+    try:
+        if provider == "openrouter":
+            api_key = os.getenv("OPENROUTER_API_KEY")
+            if not api_key:
+                click.echo("OPENROUTER_API_KEY not set")
+                return
+            model_list = llm.list_openrouter_models(api_key=api_key)
+        else:
+            model_list = llm.list_huggingface_models(search=query, limit=limit)
+    except Exception as exc:  # pragma: no cover - network failures
+        click.echo(f"Failed to list models: {exc}")
+        return
+
     for mid in model_list:
         click.echo(mid)

--- a/hyperhelix/cli/commands.py
+++ b/hyperhelix/cli/commands.py
@@ -102,7 +102,9 @@ def models(provider: str, query: str, limit: int) -> None:
     provider = provider.lower()
     try:
         if provider == "openrouter":
-            api_key = os.getenv("OPENROUTER_API_KEY")
+            from ..utils import get_api_key
+
+            api_key = get_api_key("OPENROUTER_API_KEY")
             if not api_key:
                 click.echo("OPENROUTER_API_KEY not set")
                 return

--- a/hyperhelix/utils.py
+++ b/hyperhelix/utils.py
@@ -1,0 +1,15 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_api_key(name: str, default: str | None = None) -> str | None:
+    """Return API key from the environment.
+
+    Logs a warning when the key is missing and no default is provided.
+    """
+    value = os.getenv(name, default)
+    if value is None:
+        logger.warning("%s not set", name)
+    return value

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,6 +161,16 @@ def test_export_endpoint():
     assert any(e['a'] == 'a' and e['b'] == 'b' for e in data['edges'])
 
 
+def test_chat_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        'hyperhelix.api.routers.chat.OpenAIChatModel.generate_response',
+        lambda self, msgs: 'ok',
+    )
+    resp = client.post('/chat', json={'prompt': 'hi', 'provider': 'openai'})
+    assert resp.status_code == 200
+    assert resp.json() == {'response': 'ok'}
+
+
 def test_task_endpoints():
     resp = client.post('/tasks', json={'id': 't1', 'description': 'demo'})
     assert resp.status_code == 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -149,6 +149,18 @@ def test_execute_node_endpoint():
     assert data['id'] == 'x'
 
 
+def test_export_endpoint():
+    client.post('/nodes', json={'id': 'a', 'payload': {}})
+    client.post('/nodes', json={'id': 'b', 'payload': {}})
+    client.post('/edges', json={'a': 'a', 'b': 'b'})
+    resp = client.get('/export')
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {n['id'] for n in data['nodes']}
+    assert {'a', 'b'} <= ids
+    assert any(e['a'] == 'a' and e['b'] == 'b' for e in data['edges'])
+
+
 def test_task_endpoints():
     resp = client.post('/tasks', json={'id': 't1', 'description': 'demo'})
     assert resp.status_code == 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -162,13 +162,20 @@ def test_export_endpoint():
 
 
 def test_chat_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_generate(self, msgs):
+        captured['messages'] = msgs
+        return 'ok'
+
     monkeypatch.setattr(
         'hyperhelix.api.routers.chat.OpenAIChatModel.generate_response',
-        lambda self, msgs: 'ok',
+        fake_generate,
     )
     resp = client.post('/chat', json={'prompt': 'hi', 'provider': 'openai'})
     assert resp.status_code == 200
     assert resp.json() == {'response': 'ok'}
+    assert captured['messages'][0]['role'] == 'system'
 
 
 def test_task_endpoints():

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -93,3 +93,28 @@ def test_cli_codex_stream(monkeypatch):
     assert result.exit_code == 0
     assert "stream" in result.output
     assert FakeModel.used_model == "foo-model"
+
+
+def test_cli_models_openrouter(monkeypatch):
+    monkeypatch.setattr(
+        "hyperhelix.agents.llm.list_openrouter_models",
+        lambda api_key=None: ["a", "b"],
+    )
+    runner = CliRunner()
+    result = runner.invoke(commands.cli, ["models", "--provider", "openrouter"]) 
+    assert result.exit_code == 0
+    assert "a" in result.output
+
+
+def test_cli_models_huggingface(monkeypatch):
+    monkeypatch.setattr(
+        "hyperhelix.agents.llm.list_huggingface_models",
+        lambda search="gpt2", limit=5: ["hf"],
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        commands.cli,
+        ["models", "--provider", "huggingface", "--query", "gpt2", "--limit", "1"],
+    )
+    assert result.exit_code == 0
+    assert "hf" in result.output

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
 from hyperhelix.core import HyperHelix
+import json
 
 from hyperhelix.cli import commands
 
@@ -119,3 +120,20 @@ def test_cli_models_huggingface(monkeypatch):
     )
     assert result.exit_code == 0
     assert "hf" in result.output
+
+
+def test_cli_export(monkeypatch):
+    from hyperhelix.api import main
+    from hyperhelix.core import HyperHelix
+    from hyperhelix.node import Node
+
+    main.app.state.graph = HyperHelix()
+    main.app.state.graph.add_node(Node(id="a", payload={}))
+    main.app.state.graph.add_node(Node(id="b", payload={}))
+    main.app.state.graph.add_edge("a", "b")
+    runner = CliRunner()
+    result = runner.invoke(commands.cli, ["export"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert any(n["id"] == "a" for n in data["nodes"])
+    assert any(e["a"] == "a" and e["b"] == "b" for e in data["edges"])

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -49,10 +49,13 @@ def test_cli_issues(monkeypatch):
 
 def test_cli_codex(monkeypatch):
     class FakeModel:
+        captured = None
+
         def __init__(self, *a, **kw):
             pass
 
         def generate_response(self, messages):
+            FakeModel.captured = messages
             return "pong"
 
     monkeypatch.setattr("hyperhelix.agents.llm.OpenRouterChatModel", FakeModel)
@@ -60,14 +63,18 @@ def test_cli_codex(monkeypatch):
     result = runner.invoke(commands.cli, ["codex", "ping"])
     assert result.exit_code == 0
     assert "pong" in result.output
+    assert FakeModel.captured[0]["role"] == "system"
 
 
 def test_cli_codex_local(monkeypatch):
     class FakeModel:
+        captured = None
+
         def __init__(self, *a, **kw):
             pass
 
         def generate_response(self, messages):
+            FakeModel.captured = messages
             return "loc"
 
     monkeypatch.setattr("hyperhelix.agents.llm.TransformersChatModel", FakeModel)
@@ -75,14 +82,18 @@ def test_cli_codex_local(monkeypatch):
     result = runner.invoke(commands.cli, ["codex", "hello", "--provider", "local"])
     assert result.exit_code == 0
     assert "loc" in result.output
+    assert FakeModel.captured[0]["role"] == "system"
 
 
 def test_cli_codex_stream(monkeypatch):
     class FakeModel:
+        captured = None
+
         def __init__(self, model="openai/gpt-4o", api_key=None):
             FakeModel.used_model = model
 
         def stream_response(self, messages):
+            FakeModel.captured = messages
             return "stream"
 
     monkeypatch.setattr("hyperhelix.agents.llm.OpenRouterChatModel", FakeModel)
@@ -94,6 +105,7 @@ def test_cli_codex_stream(monkeypatch):
     assert result.exit_code == 0
     assert "stream" in result.output
     assert FakeModel.used_model == "foo-model"
+    assert FakeModel.captured[0]["role"] == "system"
 
 
 def test_cli_models_openrouter(monkeypatch):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -100,8 +100,9 @@ def test_cli_models_openrouter(monkeypatch):
         "hyperhelix.agents.llm.list_openrouter_models",
         lambda api_key=None: ["a", "b"],
     )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test")
     runner = CliRunner()
-    result = runner.invoke(commands.cli, ["models", "--provider", "openrouter"]) 
+    result = runner.invoke(commands.cli, ["models", "--provider", "openrouter"])
     assert result.exit_code == 0
     assert "a" in result.output
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,6 +3,7 @@ import os
 from hyperhelix.agents.llm import (
     OpenAIChatModel,
     OpenRouterChatModel,
+    HuggingFaceChatModel,
     list_openrouter_models,
 )
 
@@ -47,4 +48,16 @@ def test_openrouter_stream_live():
 def test_list_models_live():
     models = list_openrouter_models(api_key=os.getenv('OPENROUTER_API_KEY'))
     assert isinstance(models, list) and models
+
+
+def test_openrouter_defaults_to_env(monkeypatch):
+    monkeypatch.setenv('OPENROUTER_API_KEY', 'xyz')
+    model = OpenRouterChatModel()
+    assert model.api_key == 'xyz'
+
+
+def test_huggingface_defaults_to_env(monkeypatch):
+    monkeypatch.setenv('HUGGINGFACE_API_TOKEN', 'abc')
+    model = HuggingFaceChatModel()
+    assert model.api_key == 'abc'
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+from hyperhelix.utils import get_api_key
+
+
+def test_get_api_key_env(monkeypatch):
+    monkeypatch.setenv('MY_KEY', 'val')
+    assert get_api_key('MY_KEY') == 'val'
+
+
+def test_get_api_key_warning(monkeypatch, caplog):
+    import logging
+
+    logger = logging.getLogger('hyperhelix.utils')
+    logger.propagate = True
+    monkeypatch.delenv('MISSING_KEY', raising=False)
+    assert get_api_key('MISSING_KEY') is None
+    assert logger.isEnabledFor(logging.WARNING)


### PR DESCRIPTION
## Summary
- add `models` command to CLI
- test listing LLM models
- document model listing command in README, module docs and tutorial

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688384e19718833185803f2b9e456e12