### PR TITLE
Add JSONFileAdapter for local persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Commands read provider keys such as `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and
 
 The `HyperHelix` graph accepts a persistence adapter for automatically storing
 nodes and edges. Instantiate it with an adapter such as `Neo4jAdapter` to
-persist connections as they are created.
+persist connections as they are created. For quick local experiments, the
+`JSONFileAdapter` writes graph data to a simple JSON file.
 
 Alternatively build and run the provided Dockerfile:
 
@@ -245,7 +246,8 @@ The directories above form a cohesive system:
 - **evolution/evented_engine.py** reacts instantly to insert/update hooks, pruning or weaving without polling.
 - **execution/** bridges external callables (builds, tests, deploys) into graph execution and auto-bloom hooks.
 - **tasks/** manages project tasks through graph-driven `create_task`, `assign_task` and `sprint_plan` helpers.
-- **persistence/** stores nodes and edges via pluggable adapters for Neo4j, Qdrant or SQLAlchemy.
+- **persistence/** stores nodes and edges via pluggable adapters such as
+  `JSONFileAdapter`, `Neo4jAdapter`, `QdrantAdapter` or `SQLAlchemyAdapter`.
 - **api/** exposes operations over REST and GraphQL using Pydantic schemas and optional auth stubs.
 - **cli/** offers local commands to initialise, import, export and serve the system.
 - **visualization/** generates 3D coordinates for Three.js rendering.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -6,7 +6,8 @@
 - **hyperhelix/cli/** – command-line interface helpers.
 - **hyperhelix/core.py** – graph container with `add_node`, `add_edge`, `remove_edge`, `remove_node`, `spiral_walk` and `shortest_path`.
 - **persistence adapters** – implement `save_node`, `load_node`, `save_edge` and
-  `load_edges` for automatic storage when supplied to `HyperHelix`.
+  `load_edges` for automatic storage when supplied to `HyperHelix`. The
+  `JSONFileAdapter` persists data to a local JSON file for quick experiments.
 - **hyperhelix/evolution/** – event-driven and periodic engines that update node metrics.
 - **hyperhelix/agents/code_scanner.py** – scans directories, stores Python source and links files via imports.
  - **hyperhelix/agents/llm.py** – wrappers for OpenAI, OpenRouter, HuggingFace and local Transformers chat models.

--- a/hyperhelix/persistence/__init__.py
+++ b/hyperhelix/persistence/__init__.py
@@ -1,1 +1,5 @@
 """Database adapters for storing nodes and edges."""
+
+from .json_file_adapter import JSONFileAdapter
+
+__all__ = ["JSONFileAdapter"]

--- a/hyperhelix/persistence/json_file_adapter.py
+++ b/hyperhelix/persistence/json_file_adapter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+import logging
+
+from .base_adapter import BaseAdapter
+
+
+logger = logging.getLogger("hyperhelix")
+
+
+class JSONFileAdapter(BaseAdapter):
+    """Persist nodes and edges to a JSON file.
+
+    The adapter stores a dictionary with ``nodes`` and ``edges`` keys. Nodes map to
+    their payloads while edges map a source node to dictionaries of destination
+    IDs and weights. Access is guarded by a thread lock so concurrent graph
+    operations remain safe.
+    """
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._lock = threading.Lock()
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                self.data: dict[str, dict] = json.load(f)
+        else:
+            self.data = {"nodes": {}, "edges": {}}
+
+    def _persist(self) -> None:
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump(self.data, f)
+        logger.debug("Persisted graph to %s", self.path)
+
+    def save_node(self, node_id: str, payload: dict) -> None:
+        with self._lock:
+            logger.debug("Saving node %s", node_id)
+            self.data["nodes"][node_id] = payload
+            self._persist()
+
+    def load_node(self, node_id: str) -> dict:
+        with self._lock:
+            node = self.data["nodes"].get(node_id, {})
+            logger.debug("Loaded node %s", node_id)
+            return node
+
+    def save_edge(self, a: str, b: str, weight: float) -> None:
+        with self._lock:
+            logger.debug("Saving edge %s -> %s (weight=%s)", a, b, weight)
+            edges = self.data["edges"].setdefault(a, {})
+            edges[b] = weight
+            self._persist()
+
+    def load_edges(self, node_id: str) -> dict[str, float]:
+        with self._lock:
+            edges = self.data["edges"].get(node_id, {}).copy()
+            logger.debug("Loaded %d edges for %s", len(edges), node_id)
+            return edges

--- a/tests/test_json_file_adapter.py
+++ b/tests/test_json_file_adapter.py
@@ -1,0 +1,14 @@
+from hyperhelix.persistence.json_file_adapter import JSONFileAdapter
+
+
+def test_json_file_adapter_roundtrip(tmp_path):
+    path = tmp_path / "graph.json"
+    adapter = JSONFileAdapter(path)
+    adapter.save_node("n1", {"text": "hello"})
+    assert adapter.load_node("n1") == {"text": "hello"}
+    adapter.save_edge("n1", "n2", 0.7)
+    assert adapter.load_edges("n1") == {"n2": 0.7}
+    # Ensure data persists across instances
+    adapter2 = JSONFileAdapter(path)
+    assert adapter2.load_node("n1") == {"text": "hello"}
+    assert adapter2.load_edges("n1") == {"n2": 0.7}


### PR DESCRIPTION
## Summary
- add JSONFileAdapter to persist nodes and edges in a local JSON file
- expose the adapter via persistence package and document usage
- test JSONFileAdapter round-trip save and load

## Testing
- `scripts/test_with_llm.sh` *(fails: NameError: name 'torch' is not defined / 401 Unauthorized)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab2e1af2188331a1a553e2d1802f50